### PR TITLE
pch + by

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,10 +5,18 @@ Version: 0.0.1
 Date: 2023-02-21
 Authors@R: 
   c(
-    person(given = "Grant",
-           family = "McDermott",
-           role = c("aut", "cre"),
-           email = "grantmcd@uoregon.edu"
+    person(
+      given = "Grant",
+      family = "McDermott",
+      role = c("aut", "cre"),
+      email = "grantmcd@uoregon.edu"
+    ),
+    person(
+      given = "Vincent",
+      family = "Arel-Bundock",
+      role = "ctb",
+      email = "vincent.arel-bundock@umontreal.ca",
+      comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@vincentab")
     )
   )
 Description: Lightweight extension of the base R plot function, with support for

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -197,6 +197,19 @@ plot2.default = function(
   
   ngrps = length(split_data)
     
+  # point shape
+  if (isTRUE(length(pch) == ngrps)) {
+    for (i in seq_along(split_data)) {
+      split_data[[i]][["pch"]] = pch[[i]]
+    }
+  } else if (isTRUE(length(pch) %in% 0:1)) {
+    for (i in seq_along(split_data)) {
+      split_data[[i]][["pch"]] = pch
+    }
+  } else {
+    stop(sprintf("`pch` must be `NULL` or a vector of length 1 or %s.", ngrps), call. = FALSE)
+  }
+
   # colour palette
   if (is.null(palette)) {
     if (ngrps<=9) {
@@ -261,10 +274,18 @@ plot2.default = function(
       legend = ylab
     }
     
-    pch_type = lty_type = NULL
-    if (type %in% c("p", "b", "o")) pch_type = ifelse(!is.null(pch), pch, 1)
+    lty_type = pch_type = NULL
+
+    if (type %in% c("p", "b", "o")) {
+      if (!is.null(pch)) {
+        pch_type = pch
+      } else {
+        pch_type = 1
+      }
+    }
+
     if (type %in% c("l", "b", "o")) lty_type = 1
-    
+
     if (legend.position=="bottom!") {
       
       reset_par = TRUE
@@ -357,7 +378,7 @@ plot2.default = function(
         y=split_data[[i]]$y, 
         col = cols[i], 
         type = type, 
-        pch = pch
+        pch=split_data[[i]]$pch,
         )
       )
   )
@@ -369,7 +390,7 @@ plot2.default = function(
         y=split_data[[i]]$y, 
         col = cols[i], 
         type = type,
-        pch = pch
+        pch=split_data[[i]]$pch
         )
       )
   )


### PR DESCRIPTION
This PR implements the @zeileis suggestion to make `pch` a bit smarter when using the `by` argument. See <https://github.com/grantmcdermott/plot2/issues/4#issuecomment-1500741433>

I could easily do something similar for `col` if you think this is something you would eventually want to merge.

``` r
library(plot2)

# default
with(mtcars, plot2(mpg ~ hp | gear))
```

![](https://i.imgur.com/IHzVVhY.png)<!-- -->

``` r

# manual shape: vector must be same length as number of groups
with(mtcars, plot2(mpg ~ hp | gear, pch = 2:4))
```

![](https://i.imgur.com/Ffd6MWd.png)<!-- -->

``` r

# user input sanity check
with(mtcars, plot2(mpg ~ hp | gear, pch = 1:32))
# Error: `pch` must be `NULL` or a vector of length 1 or 3.
```
