### PR TITLE
by_aesthetics.R + tinysnapshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,7 @@
 Package: plot2
 Type: Package
 Title: Easier base twoway plots
-Version: 0.0.1.9002
-Date: 2023-02-21
+Version: 0.0.1.9004
 Authors@R: 
   c(
     person(
@@ -36,6 +35,9 @@ Imports:
   grDevices,
   stats
 Suggests:
+  rsvg,
+  svglite,
+  tinysnapshot,
   tinytest,
   basetheme
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 Enhancements
 
-- Allow users to specify different `pch` types per group (#5 @vincentarelbundock).
+- Allow users to specify different `pch`, `lty`, and `col` types per group (#5 @vincentarelbundock).
 
 Bug fixes
 

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -1,0 +1,97 @@
+by_col = function(ngrps, col = NULL, palette = NULL, palette.args = NULL) {
+  
+  if (is.null(col)) {
+    col = seq_len(ngrps)
+  }
+
+  if (is.atomic(col) && is.vector(col)) {
+    if (length(col) == 1) {
+        col = rep(col, ngrps)
+    } else if (length(col) != ngrps) {
+        stop(sprintf("`col` must be of length 1 or %s.", ngrps), call. = FALSE)
+    }
+    if (is.character(col)) return(col)
+  }
+
+  if (is.null(palette)) {
+    if (ngrps<=9) {
+      palette = "Okabe-Ito"
+      palette_fun = palette.colors
+    } else {
+      palette = "Viridis"
+      palette_fun = hcl.colors
+    }
+  } else if (palette %in% palette.pals()) {
+    palette_fun = palette.colors
+  } else if (palette %in% hcl.pals()) {
+    palette_fun = hcl.colors
+  } else {
+    warning(
+      "\nPalette string not recogized. Must be a value produced by either",
+      "`palette.pals()` or `hcl.pals()`.",
+      "\nUsing default option instead.\n",
+      call. = FALSE
+      )
+    if (ngrps <= 9) {
+      palette = "Okabe-Ito"
+      palette_fun = palette.colors
+    } else {
+      palette = "Viridis"
+      palette_fun = hcl.colors
+    }
+  }
+
+  # n is a required argument for viridis and other palettes
+  if (!"n" %in% names(palette.args)) palette.args[["n"]] = max(col)
+
+  out = do.call(
+    function(...) Map(palette_fun, palette = palette, ...), 
+    args = palette.args
+    )[[1]]
+  
+  out = out[col]
+ 
+  return(out)
+
+}
+
+
+by_pch = function(ngrps, pch) {
+  if (is.null(pch)) pch = 1
+
+  if (!is.atomic(pch) || !is.vector(pch) || !is.numeric(pch) || (length(pch) != 1 && length(pch) != ngrps)) {
+    stop(sprintf("`pch` must be `NULL` or a numeric vector of length 1 or %s.", ngrps), call. = FALSE)
+  }
+  
+  if (length(pch) == 1) {
+    pch = rep(pch, ngrps)
+  }
+  
+  return(pch)
+}
+
+
+by_lty = function(ngrps, type, lty) {
+
+  # don't care about line type, return NULL
+  if (!type %in% c("l", "b", "o")) {
+    out = NULL
+
+  # NULL -> solid line
+  } else if (is.null(lty)) {
+    out = rep(1, ngrps)
+  
+  # atomic vector: sanity check length
+  } else if (is.atomic(lty) && is.vector(lty)) {
+    if (length(lty) == 1) {
+      out = rep(lty, ngrps)
+    } else {
+      if (length(lty) != ngrps) {
+        stop(sprintf("`lty` must be `NULL` or a numeric vector of length 1 or %s.", ngrps), call. = FALSE)
+      }
+      out = lty
+    }
+  }
+
+  return(out)
+}

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -378,7 +378,11 @@ plot2.default = function(
     sub = sub
     )
   
-  if (reset_par) on.exit(par(opar))
+  if (reset_par) {
+    ousr = par("usr")
+    on.exit(par(opar), add = TRUE)
+    on.exit(par(usr = ousr), add = TRUE)
+  }
   
 }
 

--- a/inst/tinytest/_tinysnapshot/aesthetics_type_b.svg
+++ b/inst/tinytest/_tinysnapshot/aesthetics_type_b.svg
@@ -1,0 +1,375 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='155.50' y='458.56' width='221.80' height='44.28' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='158.74' y1='488.08' x2='180.34' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='202.02' y1='488.08' x2='223.62' y2='488.08' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='245.30' y1='488.08' x2='266.90' y2='488.08' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='288.58' y1='488.08' x2='310.18' y2='488.08' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='331.86' y1='488.08' x2='353.46' y2='488.08' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='169.54' cy='488.08' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='212.82' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='256.10' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='299.38' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='342.66' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<text x='266.40' y='473.32' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='37.63px' lengthAdjust='spacingAndGlyphs'>Month</text>
+<text x='191.14' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='234.42' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='277.70' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='320.98' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='364.26' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>9</text>
+<line x1='61.60' y1='398.41' x2='445.60' y2='398.41' style='stroke-width: 0.75;' />
+<line x1='61.60' y1='398.41' x2='61.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='125.60' y1='398.41' x2='125.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='189.60' y1='398.41' x2='189.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='253.60' y1='398.41' x2='253.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='317.60' y1='398.41' x2='317.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='381.60' y1='398.41' x2='381.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='445.60' y1='398.41' x2='445.60' y2='405.61' style='stroke-width: 0.75;' />
+<text x='61.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='125.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='189.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='253.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='317.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='381.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='445.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>30</text>
+<line x1='59.04' y1='355.19' x2='59.04' y2='125.26' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='355.19' x2='51.84' y2='355.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='278.54' x2='51.84' y2='278.54' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='201.90' x2='51.84' y2='201.90' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='125.26' x2='51.84' y2='125.26' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,355.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,278.54) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text transform='translate(41.76,201.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,125.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>90</text>
+<polygon points='59.04,398.41 473.76,398.41 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ=='>
+    <rect x='59.04' y='59.04' width='414.72' height='339.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+<line x1='76.68' y1='294.71' x2='84.92' y2='270.04' style='stroke-width: 0.75;' />
+<line x1='91.81' y1='257.69' x2='95.39' y2='253.41' style='stroke-width: 0.75;' />
+<line x1='100.99' y1='255.02' x2='111.81' y2='332.73' style='stroke-width: 0.75;' />
+<line x1='114.73' y1='346.79' x2='123.67' y2='378.91' style='stroke-width: 0.75;' />
+<line x1='126.79' y1='378.74' x2='137.21' y2='316.30' style='stroke-width: 0.75;' />
+<line x1='144.58' y1='312.90' x2='145.02' y2='313.17' style='stroke-width: 0.75;' />
+<line x1='153.13' y1='323.80' x2='162.07' y2='355.91' style='stroke-width: 0.75;' />
+<line x1='168.61' y1='357.32' x2='172.19' y2='353.05' style='stroke-width: 0.75;' />
+<line x1='178.27' y1='340.47' x2='188.13' y2='293.26' style='stroke-width: 0.75;' />
+<line x1='191.88' y1='279.38' x2='200.12' y2='254.72' style='stroke-width: 0.75;' />
+<line x1='204.68' y1='254.72' x2='212.92' y2='279.38' style='stroke-width: 0.75;' />
+<line x1='218.70' y1='292.50' x2='224.50' y2='302.91' style='stroke-width: 0.75;' />
+<line x1='232.61' y1='303.67' x2='236.19' y2='299.40' style='stroke-width: 0.75;' />
+<line x1='241.99' y1='300.97' x2='252.41' y2='363.41' style='stroke-width: 0.75;' />
+<line x1='255.53' y1='363.58' x2='264.47' y2='331.46' style='stroke-width: 0.75;' />
+<line x1='271.01' y1='319.00' x2='274.59' y2='314.73' style='stroke-width: 0.75;' />
+<line x1='280.51' y1='316.28' x2='290.69' y2='371.10' style='stroke-width: 0.75;' />
+<line x1='293.08' y1='371.06' x2='303.72' y2='300.99' style='stroke-width: 0.75;' />
+<line x1='306.73' y1='300.81' x2='315.67' y2='332.92' style='stroke-width: 0.75;' />
+<line x1='321.10' y1='346.15' x2='326.90' y2='356.56' style='stroke-width: 0.75;' />
+<line x1='331.25' y1='355.70' x2='342.35' y2='262.70' style='stroke-width: 0.75;' />
+<line x1='344.19' y1='262.68' x2='355.01' y2='340.39' style='stroke-width: 0.75;' />
+<line x1='371.57' y1='354.16' x2='378.83' y2='371.53' style='stroke-width: 0.75;' />
+<line x1='387.78' y1='374.48' x2='388.22' y2='374.21' style='stroke-width: 0.75;' />
+<line x1='400.58' y1='374.21' x2='401.02' y2='374.48' style='stroke-width: 0.75;' />
+<line x1='408.39' y1='371.08' x2='418.81' y2='308.64' style='stroke-width: 0.75;' />
+<line x1='420.85' y1='294.39' x2='431.95' y2='201.39' style='stroke-width: 0.75;' />
+<line x1='437.41' y1='199.76' x2='440.99' y2='204.04' style='stroke-width: 0.75;' />
+<line x1='449.10' y1='215.86' x2='454.90' y2='226.27' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='87.20' cy='263.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='100.00' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='112.80' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='125.60' cy='385.84' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='138.40' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.20' cy='316.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='164.00' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='176.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='189.60' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='215.20' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='240.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='253.60' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='266.40' cy='324.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='279.20' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='292.00' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='317.60' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='343.20' cy='255.55' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='356.00' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='368.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='394.40' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='407.20' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='420.00' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='432.80' cy='194.24' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='445.60' cy='209.57' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='232.56' r='2.70' style='stroke-width: 0.75;' />
+<line x1='77.17' y1='223.87' x2='84.43' y2='241.24' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='88.87' y1='254.89' x2='98.33' y2='294.53' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='100.70' y1='294.37' x2='112.10' y2='178.41' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='118.98' y1='167.55' x2='119.42' y2='167.28' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='127.53' y1='170.52' x2='136.47' y2='202.63' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='141.90' y1='203.27' x2='147.70' y2='192.86' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='153.48' y1='179.74' x2='161.72' y2='155.08' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='167.50' y1='141.96' x2='173.30' y2='131.55' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='180.30' y1='131.55' x2='186.10' y2='141.96' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='191.53' y1='141.32' x2='200.47' y2='109.20' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='208.58' y1='105.96' x2='209.02' y2='106.23' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='216.39' y1='117.03' x2='226.81' y2='179.47' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='268.68' y1='231.72' x2='276.92' y2='256.39' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='280.87' y1='270.22' x2='290.33' y2='309.86' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='293.47' y1='309.82' x2='303.33' y2='262.60' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='308.30' y1='249.26' x2='314.10' y2='238.85' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='323.78' y1='228.86' x2='324.22' y2='228.59' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='336.58' y1='228.59' x2='337.02' y2='228.86' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='374.98' y1='236.26' x2='375.42' y2='236.52' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='385.10' y1='233.93' x2='390.90' y2='223.52' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='396.68' y1='224.06' x2='404.92' y2='248.72' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='408.87' y1='248.55' x2='418.33' y2='208.90' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='423.50' y1='208.19' x2='429.30' y2='218.60' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='434.73' y1='217.96' x2='443.67' y2='185.84' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='74.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='87.20' cy='247.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='100.00' cy='301.54' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='112.80' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='125.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='138.40' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='151.20' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='164.00' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='176.80' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='189.60' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='202.40' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='215.20' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='228.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='240.80' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='253.60' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='266.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='279.20' cy='263.21' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='292.00' cy='316.86' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='304.80' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='317.60' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='330.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='343.20' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='356.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='368.80' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='381.60' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='394.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='407.20' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='420.00' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='432.80' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='445.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='80.58' y1='167.55' x2='81.02' y2='167.28' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='89.97' y1='170.22' x2='97.23' y2='187.59' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='103.50' y1='187.95' x2='109.30' y2='177.53' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='118.98' y1='174.94' x2='119.42' y2='175.21' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='140.68' y1='172.08' x2='148.92' y2='147.42' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='153.97' y1='133.94' x2='161.23' y2='116.57' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='180.30' y1='116.22' x2='186.10' y2='126.63' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='191.27' y1='139.93' x2='200.73' y2='179.57' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='203.71' y1='193.65' x2='213.89' y2='248.47' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='216.67' y1='248.50' x2='226.53' y2='201.28' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='229.19' y1='187.14' x2='239.61' y2='124.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='241.88' y1='124.71' x2='252.52' y2='194.78' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='259.78' y1='198.20' x2='260.22' y2='197.94' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='272.58' y1='190.54' x2='273.02' y2='190.27' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='283.81' y1='181.05' x2='287.39' y2='176.77' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='295.50' y1='164.95' x2='301.30' y2='154.54' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='309.41' y1='153.78' x2='312.99' y2='158.05' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='318.68' y1='170.70' x2='329.32' y2='240.77' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='332.07' y1='240.88' x2='341.53' y2='201.24' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='349.38' y1='190.54' x2='349.82' y2='190.27' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='358.77' y1='179.93' x2='366.03' y2='162.56' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='374.98' y1='159.61' x2='375.42' y2='159.88' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='385.10' y1='169.87' x2='390.90' y2='180.28' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='397.17' y1='179.93' x2='404.43' y2='162.56' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='411.81' y1='150.39' x2='415.39' y2='146.11' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='424.61' y1='146.11' x2='428.19' y2='150.39' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='436.30' y1='162.21' x2='442.10' y2='172.62' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='450.21' y1='184.43' x2='453.79' y2='188.71' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='74.40' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='87.20' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='100.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='112.80' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='125.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='138.40' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='151.20' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='164.00' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='176.80' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='189.60' cy='132.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='202.40' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='215.20' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='228.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='240.80' cy='117.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='253.60' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='266.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='279.20' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='292.00' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='304.80' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='317.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='330.40' cy='247.89' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='343.20' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='356.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='368.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='381.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='394.40' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='407.20' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='420.00' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='432.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='445.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='458.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='93.38' y1='190.54' x2='93.82' y2='190.27' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='102.77' y1='179.93' x2='110.03' y2='162.56' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='118.98' y1='159.61' x2='119.42' y2='159.88' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='130.21' y1='158.05' x2='133.79' y2='153.78' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='143.01' y1='142.72' x2='146.59' y2='138.45' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='157.38' y1='129.22' x2='157.82' y2='128.96' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='181.41' y1='119.73' x2='184.99' y2='115.46' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='191.53' y1='116.87' x2='200.47' y2='148.98' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='217.97' y1='162.56' x2='225.23' y2='179.93' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='271.01' y1='219.37' x2='274.59' y2='215.09' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='282.70' y1='215.86' x2='288.50' y2='226.27' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='296.61' y1='227.03' x2='300.19' y2='222.76' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='323.78' y1='220.93' x2='324.22' y2='221.19' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='332.68' y1='231.72' x2='340.92' y2='256.39' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='346.70' y1='256.92' x2='352.50' y2='246.51' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='358.77' y1='233.58' x2='366.03' y2='216.21' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='373.41' y1='204.04' x2='376.99' y2='199.76' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='383.88' y1='187.41' x2='392.12' y2='162.74' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='399.01' y1='150.39' x2='402.59' y2='146.11' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='408.51' y1='133.51' x2='418.69' y2='78.69' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='423.50' y1='77.90' x2='429.30' y2='88.31' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='437.41' y1='89.08' x2='440.99' y2='84.80' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='450.21' y1='84.80' x2='453.79' y2='89.08' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='74.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='87.20' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='100.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='112.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='125.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='138.40' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='151.20' cy='132.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='164.00' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='176.80' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='189.60' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='202.40' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='215.20' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='228.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='240.80' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='253.60' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='266.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='279.20' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='292.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='304.80' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='317.60' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='330.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='343.20' cy='263.21' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='356.00' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='368.80' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='381.60' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='394.40' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='407.20' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='420.00' cy='71.61' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='432.80' cy='94.60' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='445.60' cy='79.27' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='458.40' cy='94.60' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='80.58' y1='113.90' x2='81.02' y2='113.63' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='93.38' y1='106.23' x2='93.82' y2='105.96' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='114.73' y1='109.20' x2='123.67' y2='141.32' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='129.10' y1='154.54' x2='134.90' y2='164.95' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='141.17' y1='177.89' x2='148.43' y2='195.26' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='155.81' y1='207.43' x2='159.39' y2='211.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='167.50' y1='223.52' x2='173.30' y2='233.93' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='181.41' y1='245.75' x2='184.99' y2='250.02' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='191.07' y1='248.50' x2='200.93' y2='201.28' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='204.68' y1='201.07' x2='212.92' y2='225.73' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='221.38' y1='228.86' x2='221.82' y2='228.59' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='229.93' y1='231.83' x2='238.87' y2='263.94' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='255.27' y1='263.88' x2='264.73' y2='224.23' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='267.48' y1='224.35' x2='278.12' y2='294.42' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='280.51' y1='294.46' x2='290.69' y2='239.64' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='293.47' y1='239.61' x2='303.33' y2='286.82' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='305.65' y1='286.72' x2='316.75' y2='193.72' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='318.27' y1='193.74' x2='329.73' y2='317.36' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='332.07' y1='317.52' x2='341.53' y2='277.88' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='344.39' y1='263.78' x2='354.81' y2='201.34' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='356.99' y1='201.37' x2='367.81' y2='279.08' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='370.73' y1='293.14' x2='379.67' y2='325.26' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='383.27' y1='325.19' x2='392.73' y2='285.55' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='396.07' y1='271.54' x2='405.53' y2='231.90' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='411.81' y1='230.42' x2='415.39' y2='234.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='426.18' y1='236.52' x2='426.62' y2='236.26' style='stroke-width: 0.75; stroke: #F0E442;' />
+<line x1='434.27' y1='239.61' x2='444.13' y2='286.82' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='74.40' cy='117.59' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='87.20' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='100.00' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='112.80' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='125.60' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='138.40' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='151.20' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='164.00' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='176.80' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='189.60' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='202.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='215.20' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='228.00' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='240.80' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='253.60' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='266.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='279.20' cy='301.54' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='292.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='304.80' cy='293.87' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='317.60' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='330.40' cy='324.53' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='343.20' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='356.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='368.80' cy='286.21' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='381.60' cy='332.19' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='394.40' cy='278.54' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='407.20' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='420.00' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='432.80' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='445.60' cy='293.87' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU='>
+    <rect x='0.00' y='0.00' width='504.00' height='471.85' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU=)'>
+<text x='266.40' y='453.13' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='23.71px' lengthAdjust='spacingAndGlyphs'>Day</text>
+<text transform='translate(12.96,228.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='31.99px' lengthAdjust='spacingAndGlyphs'>Temp</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/aesthetics_type_b_col_pch.svg
+++ b/inst/tinytest/_tinysnapshot/aesthetics_type_b_col_pch.svg
@@ -1,0 +1,439 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='155.50' y='458.56' width='221.80' height='44.28' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='158.74' y1='488.08' x2='180.34' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='202.02' y1='488.08' x2='223.62' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='245.30' y1='488.08' x2='266.90' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='288.58' y1='488.08' x2='310.18' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='331.86' y1='488.08' x2='353.46' y2='488.08' style='stroke-width: 0.75;' />
+<circle cx='169.54' cy='488.08' r='2.70' style='stroke-width: 0.75;' />
+<polygon points='212.82,483.88 216.46,490.18 209.18,490.18 ' style='stroke-width: 0.75;' />
+<line x1='252.28' y1='488.08' x2='259.92' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='256.10' y1='491.90' x2='256.10' y2='484.26' style='stroke-width: 0.75;' />
+<line x1='296.68' y1='490.78' x2='302.08' y2='485.38' style='stroke-width: 0.75;' />
+<line x1='296.68' y1='485.38' x2='302.08' y2='490.78' style='stroke-width: 0.75;' />
+<polygon points='338.84,488.08 342.66,484.26 346.48,488.08 342.66,491.90 ' style='stroke-width: 0.75;' />
+<text x='266.40' y='473.32' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='37.63px' lengthAdjust='spacingAndGlyphs'>Month</text>
+<text x='191.14' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='234.42' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='277.70' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='320.98' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='364.26' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>9</text>
+<line x1='61.60' y1='398.41' x2='445.60' y2='398.41' style='stroke-width: 0.75;' />
+<line x1='61.60' y1='398.41' x2='61.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='125.60' y1='398.41' x2='125.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='189.60' y1='398.41' x2='189.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='253.60' y1='398.41' x2='253.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='317.60' y1='398.41' x2='317.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='381.60' y1='398.41' x2='381.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='445.60' y1='398.41' x2='445.60' y2='405.61' style='stroke-width: 0.75;' />
+<text x='61.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='125.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='189.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='253.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='317.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='381.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='445.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>30</text>
+<line x1='59.04' y1='355.19' x2='59.04' y2='125.26' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='355.19' x2='51.84' y2='355.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='278.54' x2='51.84' y2='278.54' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='201.90' x2='51.84' y2='201.90' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='125.26' x2='51.84' y2='125.26' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,355.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,278.54) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text transform='translate(41.76,201.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,125.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>90</text>
+<polygon points='59.04,398.41 473.76,398.41 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ=='>
+    <rect x='59.04' y='59.04' width='414.72' height='339.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+<line x1='76.68' y1='294.71' x2='84.92' y2='270.04' style='stroke-width: 0.75;' />
+<line x1='91.81' y1='257.69' x2='95.39' y2='253.41' style='stroke-width: 0.75;' />
+<line x1='100.99' y1='255.02' x2='111.81' y2='332.73' style='stroke-width: 0.75;' />
+<line x1='114.73' y1='346.79' x2='123.67' y2='378.91' style='stroke-width: 0.75;' />
+<line x1='126.79' y1='378.74' x2='137.21' y2='316.30' style='stroke-width: 0.75;' />
+<line x1='144.58' y1='312.90' x2='145.02' y2='313.17' style='stroke-width: 0.75;' />
+<line x1='153.13' y1='323.80' x2='162.07' y2='355.91' style='stroke-width: 0.75;' />
+<line x1='168.61' y1='357.32' x2='172.19' y2='353.05' style='stroke-width: 0.75;' />
+<line x1='178.27' y1='340.47' x2='188.13' y2='293.26' style='stroke-width: 0.75;' />
+<line x1='191.88' y1='279.38' x2='200.12' y2='254.72' style='stroke-width: 0.75;' />
+<line x1='204.68' y1='254.72' x2='212.92' y2='279.38' style='stroke-width: 0.75;' />
+<line x1='218.70' y1='292.50' x2='224.50' y2='302.91' style='stroke-width: 0.75;' />
+<line x1='232.61' y1='303.67' x2='236.19' y2='299.40' style='stroke-width: 0.75;' />
+<line x1='241.99' y1='300.97' x2='252.41' y2='363.41' style='stroke-width: 0.75;' />
+<line x1='255.53' y1='363.58' x2='264.47' y2='331.46' style='stroke-width: 0.75;' />
+<line x1='271.01' y1='319.00' x2='274.59' y2='314.73' style='stroke-width: 0.75;' />
+<line x1='280.51' y1='316.28' x2='290.69' y2='371.10' style='stroke-width: 0.75;' />
+<line x1='293.08' y1='371.06' x2='303.72' y2='300.99' style='stroke-width: 0.75;' />
+<line x1='306.73' y1='300.81' x2='315.67' y2='332.92' style='stroke-width: 0.75;' />
+<line x1='321.10' y1='346.15' x2='326.90' y2='356.56' style='stroke-width: 0.75;' />
+<line x1='331.25' y1='355.70' x2='342.35' y2='262.70' style='stroke-width: 0.75;' />
+<line x1='344.19' y1='262.68' x2='355.01' y2='340.39' style='stroke-width: 0.75;' />
+<line x1='371.57' y1='354.16' x2='378.83' y2='371.53' style='stroke-width: 0.75;' />
+<line x1='387.78' y1='374.48' x2='388.22' y2='374.21' style='stroke-width: 0.75;' />
+<line x1='400.58' y1='374.21' x2='401.02' y2='374.48' style='stroke-width: 0.75;' />
+<line x1='408.39' y1='371.08' x2='418.81' y2='308.64' style='stroke-width: 0.75;' />
+<line x1='420.85' y1='294.39' x2='431.95' y2='201.39' style='stroke-width: 0.75;' />
+<line x1='437.41' y1='199.76' x2='440.99' y2='204.04' style='stroke-width: 0.75;' />
+<line x1='449.10' y1='215.86' x2='454.90' y2='226.27' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='87.20' cy='263.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='100.00' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='112.80' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='125.60' cy='385.84' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='138.40' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.20' cy='316.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='164.00' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='176.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='189.60' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='215.20' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='240.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='253.60' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='266.40' cy='324.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='279.20' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='292.00' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='317.60' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='343.20' cy='255.55' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='356.00' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='368.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='394.40' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='407.20' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='420.00' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='432.80' cy='194.24' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='445.60' cy='209.57' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='232.56' r='2.70' style='stroke-width: 0.75;' />
+<line x1='77.17' y1='223.87' x2='84.43' y2='241.24' style='stroke-width: 0.75;' />
+<line x1='88.87' y1='254.89' x2='98.33' y2='294.53' style='stroke-width: 0.75;' />
+<line x1='100.70' y1='294.37' x2='112.10' y2='178.41' style='stroke-width: 0.75;' />
+<line x1='118.98' y1='167.55' x2='119.42' y2='167.28' style='stroke-width: 0.75;' />
+<line x1='127.53' y1='170.52' x2='136.47' y2='202.63' style='stroke-width: 0.75;' />
+<line x1='141.90' y1='203.27' x2='147.70' y2='192.86' style='stroke-width: 0.75;' />
+<line x1='153.48' y1='179.74' x2='161.72' y2='155.08' style='stroke-width: 0.75;' />
+<line x1='167.50' y1='141.96' x2='173.30' y2='131.55' style='stroke-width: 0.75;' />
+<line x1='180.30' y1='131.55' x2='186.10' y2='141.96' style='stroke-width: 0.75;' />
+<line x1='191.53' y1='141.32' x2='200.47' y2='109.20' style='stroke-width: 0.75;' />
+<line x1='208.58' y1='105.96' x2='209.02' y2='106.23' style='stroke-width: 0.75;' />
+<line x1='216.39' y1='117.03' x2='226.81' y2='179.47' style='stroke-width: 0.75;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75;' />
+<line x1='268.68' y1='231.72' x2='276.92' y2='256.39' style='stroke-width: 0.75;' />
+<line x1='280.87' y1='270.22' x2='290.33' y2='309.86' style='stroke-width: 0.75;' />
+<line x1='293.47' y1='309.82' x2='303.33' y2='262.60' style='stroke-width: 0.75;' />
+<line x1='308.30' y1='249.26' x2='314.10' y2='238.85' style='stroke-width: 0.75;' />
+<line x1='323.78' y1='228.86' x2='324.22' y2='228.59' style='stroke-width: 0.75;' />
+<line x1='336.58' y1='228.59' x2='337.02' y2='228.86' style='stroke-width: 0.75;' />
+<line x1='374.98' y1='236.26' x2='375.42' y2='236.52' style='stroke-width: 0.75;' />
+<line x1='385.10' y1='233.93' x2='390.90' y2='223.52' style='stroke-width: 0.75;' />
+<line x1='396.68' y1='224.06' x2='404.92' y2='248.72' style='stroke-width: 0.75;' />
+<line x1='408.87' y1='248.55' x2='418.33' y2='208.90' style='stroke-width: 0.75;' />
+<line x1='423.50' y1='208.19' x2='429.30' y2='218.60' style='stroke-width: 0.75;' />
+<line x1='434.73' y1='217.96' x2='443.67' y2='185.84' style='stroke-width: 0.75;' />
+<polygon points='74.40,213.03 78.04,219.33 70.76,219.33 ' style='stroke-width: 0.75;' />
+<polygon points='87.20,243.69 90.84,249.99 83.56,249.99 ' style='stroke-width: 0.75;' />
+<polygon points='100.00,297.34 103.64,303.63 96.36,303.63 ' style='stroke-width: 0.75;' />
+<polygon points='112.80,167.05 116.44,173.34 109.16,173.34 ' style='stroke-width: 0.75;' />
+<polygon points='125.60,159.38 129.24,165.68 121.96,165.68 ' style='stroke-width: 0.75;' />
+<polygon points='138.40,205.37 142.04,211.66 134.76,211.66 ' style='stroke-width: 0.75;' />
+<polygon points='151.20,182.37 154.84,188.67 147.56,188.67 ' style='stroke-width: 0.75;' />
+<polygon points='164.00,144.05 167.64,150.35 160.36,150.35 ' style='stroke-width: 0.75;' />
+<polygon points='176.80,121.06 180.44,127.36 173.16,127.36 ' style='stroke-width: 0.75;' />
+<polygon points='189.60,144.05 193.24,150.35 185.96,150.35 ' style='stroke-width: 0.75;' />
+<polygon points='202.40,98.07 206.04,104.37 198.76,104.37 ' style='stroke-width: 0.75;' />
+<polygon points='215.20,105.73 218.84,112.03 211.56,112.03 ' style='stroke-width: 0.75;' />
+<polygon points='228.00,182.37 231.64,188.67 224.36,188.67 ' style='stroke-width: 0.75;' />
+<polygon points='240.80,197.70 244.44,204.00 237.16,204.00 ' style='stroke-width: 0.75;' />
+<polygon points='253.60,205.37 257.24,211.66 249.96,211.66 ' style='stroke-width: 0.75;' />
+<polygon points='266.40,220.69 270.04,226.99 262.76,226.99 ' style='stroke-width: 0.75;' />
+<polygon points='279.20,259.02 282.84,265.31 275.56,265.31 ' style='stroke-width: 0.75;' />
+<polygon points='292.00,312.67 295.64,318.96 288.36,318.96 ' style='stroke-width: 0.75;' />
+<polygon points='304.80,251.35 308.44,257.65 301.16,257.65 ' style='stroke-width: 0.75;' />
+<polygon points='317.60,228.36 321.24,234.66 313.96,234.66 ' style='stroke-width: 0.75;' />
+<polygon points='330.40,220.69 334.04,226.99 326.76,226.99 ' style='stroke-width: 0.75;' />
+<polygon points='343.20,228.36 346.84,234.66 339.56,234.66 ' style='stroke-width: 0.75;' />
+<polygon points='356.00,228.36 359.64,234.66 352.36,234.66 ' style='stroke-width: 0.75;' />
+<polygon points='368.80,228.36 372.44,234.66 365.16,234.66 ' style='stroke-width: 0.75;' />
+<polygon points='381.60,236.02 385.24,242.32 377.96,242.32 ' style='stroke-width: 0.75;' />
+<polygon points='394.40,213.03 398.04,219.33 390.76,219.33 ' style='stroke-width: 0.75;' />
+<polygon points='407.20,251.35 410.84,257.65 403.56,257.65 ' style='stroke-width: 0.75;' />
+<polygon points='420.00,197.70 423.64,204.00 416.36,204.00 ' style='stroke-width: 0.75;' />
+<polygon points='432.80,220.69 436.44,226.99 429.16,226.99 ' style='stroke-width: 0.75;' />
+<polygon points='445.60,174.71 449.24,181.01 441.96,181.01 ' style='stroke-width: 0.75;' />
+<line x1='80.58' y1='167.55' x2='81.02' y2='167.28' style='stroke-width: 0.75;' />
+<line x1='89.97' y1='170.22' x2='97.23' y2='187.59' style='stroke-width: 0.75;' />
+<line x1='103.50' y1='187.95' x2='109.30' y2='177.53' style='stroke-width: 0.75;' />
+<line x1='118.98' y1='174.94' x2='119.42' y2='175.21' style='stroke-width: 0.75;' />
+<line x1='140.68' y1='172.08' x2='148.92' y2='147.42' style='stroke-width: 0.75;' />
+<line x1='153.97' y1='133.94' x2='161.23' y2='116.57' style='stroke-width: 0.75;' />
+<line x1='180.30' y1='116.22' x2='186.10' y2='126.63' style='stroke-width: 0.75;' />
+<line x1='191.27' y1='139.93' x2='200.73' y2='179.57' style='stroke-width: 0.75;' />
+<line x1='203.71' y1='193.65' x2='213.89' y2='248.47' style='stroke-width: 0.75;' />
+<line x1='216.67' y1='248.50' x2='226.53' y2='201.28' style='stroke-width: 0.75;' />
+<line x1='229.19' y1='187.14' x2='239.61' y2='124.70' style='stroke-width: 0.75;' />
+<line x1='241.88' y1='124.71' x2='252.52' y2='194.78' style='stroke-width: 0.75;' />
+<line x1='259.78' y1='198.20' x2='260.22' y2='197.94' style='stroke-width: 0.75;' />
+<line x1='272.58' y1='190.54' x2='273.02' y2='190.27' style='stroke-width: 0.75;' />
+<line x1='283.81' y1='181.05' x2='287.39' y2='176.77' style='stroke-width: 0.75;' />
+<line x1='295.50' y1='164.95' x2='301.30' y2='154.54' style='stroke-width: 0.75;' />
+<line x1='309.41' y1='153.78' x2='312.99' y2='158.05' style='stroke-width: 0.75;' />
+<line x1='318.68' y1='170.70' x2='329.32' y2='240.77' style='stroke-width: 0.75;' />
+<line x1='332.07' y1='240.88' x2='341.53' y2='201.24' style='stroke-width: 0.75;' />
+<line x1='349.38' y1='190.54' x2='349.82' y2='190.27' style='stroke-width: 0.75;' />
+<line x1='358.77' y1='179.93' x2='366.03' y2='162.56' style='stroke-width: 0.75;' />
+<line x1='374.98' y1='159.61' x2='375.42' y2='159.88' style='stroke-width: 0.75;' />
+<line x1='385.10' y1='169.87' x2='390.90' y2='180.28' style='stroke-width: 0.75;' />
+<line x1='397.17' y1='179.93' x2='404.43' y2='162.56' style='stroke-width: 0.75;' />
+<line x1='411.81' y1='150.39' x2='415.39' y2='146.11' style='stroke-width: 0.75;' />
+<line x1='424.61' y1='146.11' x2='428.19' y2='150.39' style='stroke-width: 0.75;' />
+<line x1='436.30' y1='162.21' x2='442.10' y2='172.62' style='stroke-width: 0.75;' />
+<line x1='450.21' y1='184.43' x2='453.79' y2='188.71' style='stroke-width: 0.75;' />
+<line x1='70.58' y1='171.24' x2='78.22' y2='171.24' style='stroke-width: 0.75;' />
+<line x1='74.40' y1='175.06' x2='74.40' y2='167.43' style='stroke-width: 0.75;' />
+<line x1='83.38' y1='163.58' x2='91.02' y2='163.58' style='stroke-width: 0.75;' />
+<line x1='87.20' y1='167.40' x2='87.20' y2='159.76' style='stroke-width: 0.75;' />
+<line x1='96.18' y1='194.24' x2='103.82' y2='194.24' style='stroke-width: 0.75;' />
+<line x1='100.00' y1='198.06' x2='100.00' y2='190.42' style='stroke-width: 0.75;' />
+<line x1='108.98' y1='171.24' x2='116.62' y2='171.24' style='stroke-width: 0.75;' />
+<line x1='112.80' y1='175.06' x2='112.80' y2='167.43' style='stroke-width: 0.75;' />
+<line x1='121.78' y1='178.91' x2='129.42' y2='178.91' style='stroke-width: 0.75;' />
+<line x1='125.60' y1='182.73' x2='125.60' y2='175.09' style='stroke-width: 0.75;' />
+<line x1='134.58' y1='178.91' x2='142.22' y2='178.91' style='stroke-width: 0.75;' />
+<line x1='138.40' y1='182.73' x2='138.40' y2='175.09' style='stroke-width: 0.75;' />
+<line x1='147.38' y1='140.59' x2='155.02' y2='140.59' style='stroke-width: 0.75;' />
+<line x1='151.20' y1='144.41' x2='151.20' y2='136.77' style='stroke-width: 0.75;' />
+<line x1='160.18' y1='109.93' x2='167.82' y2='109.93' style='stroke-width: 0.75;' />
+<line x1='164.00' y1='113.75' x2='164.00' y2='106.11' style='stroke-width: 0.75;' />
+<line x1='172.98' y1='109.93' x2='180.62' y2='109.93' style='stroke-width: 0.75;' />
+<line x1='176.80' y1='113.75' x2='176.80' y2='106.11' style='stroke-width: 0.75;' />
+<line x1='185.78' y1='132.92' x2='193.42' y2='132.92' style='stroke-width: 0.75;' />
+<line x1='189.60' y1='136.74' x2='189.60' y2='129.10' style='stroke-width: 0.75;' />
+<line x1='198.58' y1='186.57' x2='206.22' y2='186.57' style='stroke-width: 0.75;' />
+<line x1='202.40' y1='190.39' x2='202.40' y2='182.75' style='stroke-width: 0.75;' />
+<line x1='211.38' y1='255.55' x2='219.02' y2='255.55' style='stroke-width: 0.75;' />
+<line x1='215.20' y1='259.37' x2='215.20' y2='251.73' style='stroke-width: 0.75;' />
+<line x1='224.18' y1='194.24' x2='231.82' y2='194.24' style='stroke-width: 0.75;' />
+<line x1='228.00' y1='198.06' x2='228.00' y2='190.42' style='stroke-width: 0.75;' />
+<line x1='236.98' y1='117.59' x2='244.62' y2='117.59' style='stroke-width: 0.75;' />
+<line x1='240.80' y1='121.41' x2='240.80' y2='113.78' style='stroke-width: 0.75;' />
+<line x1='249.78' y1='201.90' x2='257.42' y2='201.90' style='stroke-width: 0.75;' />
+<line x1='253.60' y1='205.72' x2='253.60' y2='198.08' style='stroke-width: 0.75;' />
+<line x1='262.58' y1='194.24' x2='270.22' y2='194.24' style='stroke-width: 0.75;' />
+<line x1='266.40' y1='198.06' x2='266.40' y2='190.42' style='stroke-width: 0.75;' />
+<line x1='275.38' y1='186.57' x2='283.02' y2='186.57' style='stroke-width: 0.75;' />
+<line x1='279.20' y1='190.39' x2='279.20' y2='182.75' style='stroke-width: 0.75;' />
+<line x1='288.18' y1='171.24' x2='295.82' y2='171.24' style='stroke-width: 0.75;' />
+<line x1='292.00' y1='175.06' x2='292.00' y2='167.43' style='stroke-width: 0.75;' />
+<line x1='300.98' y1='148.25' x2='308.62' y2='148.25' style='stroke-width: 0.75;' />
+<line x1='304.80' y1='152.07' x2='304.80' y2='144.43' style='stroke-width: 0.75;' />
+<line x1='313.78' y1='163.58' x2='321.42' y2='163.58' style='stroke-width: 0.75;' />
+<line x1='317.60' y1='167.40' x2='317.60' y2='159.76' style='stroke-width: 0.75;' />
+<line x1='326.58' y1='247.89' x2='334.22' y2='247.89' style='stroke-width: 0.75;' />
+<line x1='330.40' y1='251.70' x2='330.40' y2='244.07' style='stroke-width: 0.75;' />
+<line x1='339.38' y1='194.24' x2='347.02' y2='194.24' style='stroke-width: 0.75;' />
+<line x1='343.20' y1='198.06' x2='343.20' y2='190.42' style='stroke-width: 0.75;' />
+<line x1='352.18' y1='186.57' x2='359.82' y2='186.57' style='stroke-width: 0.75;' />
+<line x1='356.00' y1='190.39' x2='356.00' y2='182.75' style='stroke-width: 0.75;' />
+<line x1='364.98' y1='155.92' x2='372.62' y2='155.92' style='stroke-width: 0.75;' />
+<line x1='368.80' y1='159.73' x2='368.80' y2='152.10' style='stroke-width: 0.75;' />
+<line x1='377.78' y1='163.58' x2='385.42' y2='163.58' style='stroke-width: 0.75;' />
+<line x1='381.60' y1='167.40' x2='381.60' y2='159.76' style='stroke-width: 0.75;' />
+<line x1='390.58' y1='186.57' x2='398.22' y2='186.57' style='stroke-width: 0.75;' />
+<line x1='394.40' y1='190.39' x2='394.40' y2='182.75' style='stroke-width: 0.75;' />
+<line x1='403.38' y1='155.92' x2='411.02' y2='155.92' style='stroke-width: 0.75;' />
+<line x1='407.20' y1='159.73' x2='407.20' y2='152.10' style='stroke-width: 0.75;' />
+<line x1='416.18' y1='140.59' x2='423.82' y2='140.59' style='stroke-width: 0.75;' />
+<line x1='420.00' y1='144.41' x2='420.00' y2='136.77' style='stroke-width: 0.75;' />
+<line x1='428.98' y1='155.92' x2='436.62' y2='155.92' style='stroke-width: 0.75;' />
+<line x1='432.80' y1='159.73' x2='432.80' y2='152.10' style='stroke-width: 0.75;' />
+<line x1='441.78' y1='178.91' x2='449.42' y2='178.91' style='stroke-width: 0.75;' />
+<line x1='445.60' y1='182.73' x2='445.60' y2='175.09' style='stroke-width: 0.75;' />
+<line x1='454.58' y1='194.24' x2='462.22' y2='194.24' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='198.06' x2='458.40' y2='190.42' style='stroke-width: 0.75;' />
+<line x1='93.38' y1='190.54' x2='93.82' y2='190.27' style='stroke-width: 0.75;' />
+<line x1='102.77' y1='179.93' x2='110.03' y2='162.56' style='stroke-width: 0.75;' />
+<line x1='118.98' y1='159.61' x2='119.42' y2='159.88' style='stroke-width: 0.75;' />
+<line x1='130.21' y1='158.05' x2='133.79' y2='153.78' style='stroke-width: 0.75;' />
+<line x1='143.01' y1='142.72' x2='146.59' y2='138.45' style='stroke-width: 0.75;' />
+<line x1='157.38' y1='129.22' x2='157.82' y2='128.96' style='stroke-width: 0.75;' />
+<line x1='181.41' y1='119.73' x2='184.99' y2='115.46' style='stroke-width: 0.75;' />
+<line x1='191.53' y1='116.87' x2='200.47' y2='148.98' style='stroke-width: 0.75;' />
+<line x1='217.97' y1='162.56' x2='225.23' y2='179.93' style='stroke-width: 0.75;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75;' />
+<line x1='271.01' y1='219.37' x2='274.59' y2='215.09' style='stroke-width: 0.75;' />
+<line x1='282.70' y1='215.86' x2='288.50' y2='226.27' style='stroke-width: 0.75;' />
+<line x1='296.61' y1='227.03' x2='300.19' y2='222.76' style='stroke-width: 0.75;' />
+<line x1='323.78' y1='220.93' x2='324.22' y2='221.19' style='stroke-width: 0.75;' />
+<line x1='332.68' y1='231.72' x2='340.92' y2='256.39' style='stroke-width: 0.75;' />
+<line x1='346.70' y1='256.92' x2='352.50' y2='246.51' style='stroke-width: 0.75;' />
+<line x1='358.77' y1='233.58' x2='366.03' y2='216.21' style='stroke-width: 0.75;' />
+<line x1='373.41' y1='204.04' x2='376.99' y2='199.76' style='stroke-width: 0.75;' />
+<line x1='383.88' y1='187.41' x2='392.12' y2='162.74' style='stroke-width: 0.75;' />
+<line x1='399.01' y1='150.39' x2='402.59' y2='146.11' style='stroke-width: 0.75;' />
+<line x1='408.51' y1='133.51' x2='418.69' y2='78.69' style='stroke-width: 0.75;' />
+<line x1='423.50' y1='77.90' x2='429.30' y2='88.31' style='stroke-width: 0.75;' />
+<line x1='437.41' y1='89.08' x2='440.99' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='450.21' y1='84.80' x2='453.79' y2='89.08' style='stroke-width: 0.75;' />
+<line x1='71.70' y1='196.94' x2='77.10' y2='191.54' style='stroke-width: 0.75;' />
+<line x1='71.70' y1='191.54' x2='77.10' y2='196.94' style='stroke-width: 0.75;' />
+<line x1='84.50' y1='196.94' x2='89.90' y2='191.54' style='stroke-width: 0.75;' />
+<line x1='84.50' y1='191.54' x2='89.90' y2='196.94' style='stroke-width: 0.75;' />
+<line x1='97.30' y1='189.27' x2='102.70' y2='183.87' style='stroke-width: 0.75;' />
+<line x1='97.30' y1='183.87' x2='102.70' y2='189.27' style='stroke-width: 0.75;' />
+<line x1='110.10' y1='158.62' x2='115.50' y2='153.22' style='stroke-width: 0.75;' />
+<line x1='110.10' y1='153.22' x2='115.50' y2='158.62' style='stroke-width: 0.75;' />
+<line x1='122.90' y1='166.28' x2='128.30' y2='160.88' style='stroke-width: 0.75;' />
+<line x1='122.90' y1='160.88' x2='128.30' y2='166.28' style='stroke-width: 0.75;' />
+<line x1='135.70' y1='150.95' x2='141.10' y2='145.55' style='stroke-width: 0.75;' />
+<line x1='135.70' y1='145.55' x2='141.10' y2='150.95' style='stroke-width: 0.75;' />
+<line x1='148.50' y1='135.62' x2='153.90' y2='130.22' style='stroke-width: 0.75;' />
+<line x1='148.50' y1='130.22' x2='153.90' y2='135.62' style='stroke-width: 0.75;' />
+<line x1='161.30' y1='127.96' x2='166.70' y2='122.56' style='stroke-width: 0.75;' />
+<line x1='161.30' y1='122.56' x2='166.70' y2='127.96' style='stroke-width: 0.75;' />
+<line x1='174.10' y1='127.96' x2='179.50' y2='122.56' style='stroke-width: 0.75;' />
+<line x1='174.10' y1='122.56' x2='179.50' y2='127.96' style='stroke-width: 0.75;' />
+<line x1='186.90' y1='112.63' x2='192.30' y2='107.23' style='stroke-width: 0.75;' />
+<line x1='186.90' y1='107.23' x2='192.30' y2='112.63' style='stroke-width: 0.75;' />
+<line x1='199.70' y1='158.62' x2='205.10' y2='153.22' style='stroke-width: 0.75;' />
+<line x1='199.70' y1='153.22' x2='205.10' y2='158.62' style='stroke-width: 0.75;' />
+<line x1='212.50' y1='158.62' x2='217.90' y2='153.22' style='stroke-width: 0.75;' />
+<line x1='212.50' y1='153.22' x2='217.90' y2='158.62' style='stroke-width: 0.75;' />
+<line x1='225.30' y1='189.27' x2='230.70' y2='183.87' style='stroke-width: 0.75;' />
+<line x1='225.30' y1='183.87' x2='230.70' y2='189.27' style='stroke-width: 0.75;' />
+<line x1='238.10' y1='204.60' x2='243.50' y2='199.20' style='stroke-width: 0.75;' />
+<line x1='238.10' y1='199.20' x2='243.50' y2='204.60' style='stroke-width: 0.75;' />
+<line x1='250.90' y1='212.27' x2='256.30' y2='206.87' style='stroke-width: 0.75;' />
+<line x1='250.90' y1='206.87' x2='256.30' y2='212.27' style='stroke-width: 0.75;' />
+<line x1='263.70' y1='227.59' x2='269.10' y2='222.19' style='stroke-width: 0.75;' />
+<line x1='263.70' y1='222.19' x2='269.10' y2='227.59' style='stroke-width: 0.75;' />
+<line x1='276.50' y1='212.27' x2='281.90' y2='206.87' style='stroke-width: 0.75;' />
+<line x1='276.50' y1='206.87' x2='281.90' y2='212.27' style='stroke-width: 0.75;' />
+<line x1='289.30' y1='235.26' x2='294.70' y2='229.86' style='stroke-width: 0.75;' />
+<line x1='289.30' y1='229.86' x2='294.70' y2='235.26' style='stroke-width: 0.75;' />
+<line x1='302.10' y1='219.93' x2='307.50' y2='214.53' style='stroke-width: 0.75;' />
+<line x1='302.10' y1='214.53' x2='307.50' y2='219.93' style='stroke-width: 0.75;' />
+<line x1='314.90' y1='219.93' x2='320.30' y2='214.53' style='stroke-width: 0.75;' />
+<line x1='314.90' y1='214.53' x2='320.30' y2='219.93' style='stroke-width: 0.75;' />
+<line x1='327.70' y1='227.59' x2='333.10' y2='222.19' style='stroke-width: 0.75;' />
+<line x1='327.70' y1='222.19' x2='333.10' y2='227.59' style='stroke-width: 0.75;' />
+<line x1='340.50' y1='265.91' x2='345.90' y2='260.51' style='stroke-width: 0.75;' />
+<line x1='340.50' y1='260.51' x2='345.90' y2='265.91' style='stroke-width: 0.75;' />
+<line x1='353.30' y1='242.92' x2='358.70' y2='237.52' style='stroke-width: 0.75;' />
+<line x1='353.30' y1='237.52' x2='358.70' y2='242.92' style='stroke-width: 0.75;' />
+<line x1='366.10' y1='212.27' x2='371.50' y2='206.87' style='stroke-width: 0.75;' />
+<line x1='366.10' y1='206.87' x2='371.50' y2='212.27' style='stroke-width: 0.75;' />
+<line x1='378.90' y1='196.94' x2='384.30' y2='191.54' style='stroke-width: 0.75;' />
+<line x1='378.90' y1='191.54' x2='384.30' y2='196.94' style='stroke-width: 0.75;' />
+<line x1='391.70' y1='158.62' x2='397.10' y2='153.22' style='stroke-width: 0.75;' />
+<line x1='391.70' y1='153.22' x2='397.10' y2='158.62' style='stroke-width: 0.75;' />
+<line x1='404.50' y1='143.29' x2='409.90' y2='137.89' style='stroke-width: 0.75;' />
+<line x1='404.50' y1='137.89' x2='409.90' y2='143.29' style='stroke-width: 0.75;' />
+<line x1='417.30' y1='74.31' x2='422.70' y2='68.91' style='stroke-width: 0.75;' />
+<line x1='417.30' y1='68.91' x2='422.70' y2='74.31' style='stroke-width: 0.75;' />
+<line x1='430.10' y1='97.30' x2='435.50' y2='91.90' style='stroke-width: 0.75;' />
+<line x1='430.10' y1='91.90' x2='435.50' y2='97.30' style='stroke-width: 0.75;' />
+<line x1='442.90' y1='81.97' x2='448.30' y2='76.57' style='stroke-width: 0.75;' />
+<line x1='442.90' y1='76.57' x2='448.30' y2='81.97' style='stroke-width: 0.75;' />
+<line x1='455.70' y1='97.30' x2='461.10' y2='91.90' style='stroke-width: 0.75;' />
+<line x1='455.70' y1='91.90' x2='461.10' y2='97.30' style='stroke-width: 0.75;' />
+<line x1='80.58' y1='113.90' x2='81.02' y2='113.63' style='stroke-width: 0.75;' />
+<line x1='93.38' y1='106.23' x2='93.82' y2='105.96' style='stroke-width: 0.75;' />
+<line x1='114.73' y1='109.20' x2='123.67' y2='141.32' style='stroke-width: 0.75;' />
+<line x1='129.10' y1='154.54' x2='134.90' y2='164.95' style='stroke-width: 0.75;' />
+<line x1='141.17' y1='177.89' x2='148.43' y2='195.26' style='stroke-width: 0.75;' />
+<line x1='155.81' y1='207.43' x2='159.39' y2='211.70' style='stroke-width: 0.75;' />
+<line x1='167.50' y1='223.52' x2='173.30' y2='233.93' style='stroke-width: 0.75;' />
+<line x1='181.41' y1='245.75' x2='184.99' y2='250.02' style='stroke-width: 0.75;' />
+<line x1='191.07' y1='248.50' x2='200.93' y2='201.28' style='stroke-width: 0.75;' />
+<line x1='204.68' y1='201.07' x2='212.92' y2='225.73' style='stroke-width: 0.75;' />
+<line x1='221.38' y1='228.86' x2='221.82' y2='228.59' style='stroke-width: 0.75;' />
+<line x1='229.93' y1='231.83' x2='238.87' y2='263.94' style='stroke-width: 0.75;' />
+<line x1='255.27' y1='263.88' x2='264.73' y2='224.23' style='stroke-width: 0.75;' />
+<line x1='267.48' y1='224.35' x2='278.12' y2='294.42' style='stroke-width: 0.75;' />
+<line x1='280.51' y1='294.46' x2='290.69' y2='239.64' style='stroke-width: 0.75;' />
+<line x1='293.47' y1='239.61' x2='303.33' y2='286.82' style='stroke-width: 0.75;' />
+<line x1='305.65' y1='286.72' x2='316.75' y2='193.72' style='stroke-width: 0.75;' />
+<line x1='318.27' y1='193.74' x2='329.73' y2='317.36' style='stroke-width: 0.75;' />
+<line x1='332.07' y1='317.52' x2='341.53' y2='277.88' style='stroke-width: 0.75;' />
+<line x1='344.39' y1='263.78' x2='354.81' y2='201.34' style='stroke-width: 0.75;' />
+<line x1='356.99' y1='201.37' x2='367.81' y2='279.08' style='stroke-width: 0.75;' />
+<line x1='370.73' y1='293.14' x2='379.67' y2='325.26' style='stroke-width: 0.75;' />
+<line x1='383.27' y1='325.19' x2='392.73' y2='285.55' style='stroke-width: 0.75;' />
+<line x1='396.07' y1='271.54' x2='405.53' y2='231.90' style='stroke-width: 0.75;' />
+<line x1='411.81' y1='230.42' x2='415.39' y2='234.70' style='stroke-width: 0.75;' />
+<line x1='426.18' y1='236.52' x2='426.62' y2='236.26' style='stroke-width: 0.75;' />
+<line x1='434.27' y1='239.61' x2='444.13' y2='286.82' style='stroke-width: 0.75;' />
+<polygon points='70.58,117.59 74.40,113.78 78.22,117.59 74.40,121.41 ' style='stroke-width: 0.75;' />
+<polygon points='83.38,109.93 87.20,106.11 91.02,109.93 87.20,113.75 ' style='stroke-width: 0.75;' />
+<polygon points='96.18,102.27 100.00,98.45 103.82,102.27 100.00,106.08 ' style='stroke-width: 0.75;' />
+<polygon points='108.98,102.27 112.80,98.45 116.62,102.27 112.80,106.08 ' style='stroke-width: 0.75;' />
+<polygon points='121.78,148.25 125.60,144.43 129.42,148.25 125.60,152.07 ' style='stroke-width: 0.75;' />
+<polygon points='134.58,171.24 138.40,167.43 142.22,171.24 138.40,175.06 ' style='stroke-width: 0.75;' />
+<polygon points='147.38,201.90 151.20,198.08 155.02,201.90 151.20,205.72 ' style='stroke-width: 0.75;' />
+<polygon points='160.18,217.23 164.00,213.41 167.82,217.23 164.00,221.05 ' style='stroke-width: 0.75;' />
+<polygon points='172.98,240.22 176.80,236.40 180.62,240.22 176.80,244.04 ' style='stroke-width: 0.75;' />
+<polygon points='185.78,255.55 189.60,251.73 193.42,255.55 189.60,259.37 ' style='stroke-width: 0.75;' />
+<polygon points='198.58,194.24 202.40,190.42 206.22,194.24 202.40,198.06 ' style='stroke-width: 0.75;' />
+<polygon points='211.38,232.56 215.20,228.74 219.02,232.56 215.20,236.38 ' style='stroke-width: 0.75;' />
+<polygon points='224.18,224.89 228.00,221.08 231.82,224.89 228.00,228.71 ' style='stroke-width: 0.75;' />
+<polygon points='236.98,270.88 240.80,267.06 244.62,270.88 240.80,274.70 ' style='stroke-width: 0.75;' />
+<polygon points='249.78,270.88 253.60,267.06 257.42,270.88 253.60,274.70 ' style='stroke-width: 0.75;' />
+<polygon points='262.58,217.23 266.40,213.41 270.22,217.23 266.40,221.05 ' style='stroke-width: 0.75;' />
+<polygon points='275.38,301.54 279.20,297.72 283.02,301.54 279.20,305.35 ' style='stroke-width: 0.75;' />
+<polygon points='288.18,232.56 292.00,228.74 295.82,232.56 292.00,236.38 ' style='stroke-width: 0.75;' />
+<polygon points='300.98,293.87 304.80,290.05 308.62,293.87 304.80,297.69 ' style='stroke-width: 0.75;' />
+<polygon points='313.78,186.57 317.60,182.75 321.42,186.57 317.60,190.39 ' style='stroke-width: 0.75;' />
+<polygon points='326.58,324.53 330.40,320.71 334.22,324.53 330.40,328.35 ' style='stroke-width: 0.75;' />
+<polygon points='339.38,270.88 343.20,267.06 347.02,270.88 343.20,274.70 ' style='stroke-width: 0.75;' />
+<polygon points='352.18,194.24 356.00,190.42 359.82,194.24 356.00,198.06 ' style='stroke-width: 0.75;' />
+<polygon points='364.98,286.21 368.80,282.39 372.62,286.21 368.80,290.03 ' style='stroke-width: 0.75;' />
+<polygon points='377.78,332.19 381.60,328.37 385.42,332.19 381.60,336.01 ' style='stroke-width: 0.75;' />
+<polygon points='390.58,278.54 394.40,274.72 398.22,278.54 394.40,282.36 ' style='stroke-width: 0.75;' />
+<polygon points='403.38,224.89 407.20,221.08 411.02,224.89 407.20,228.71 ' style='stroke-width: 0.75;' />
+<polygon points='416.18,240.22 420.00,236.40 423.82,240.22 420.00,244.04 ' style='stroke-width: 0.75;' />
+<polygon points='428.98,232.56 432.80,228.74 436.62,232.56 432.80,236.38 ' style='stroke-width: 0.75;' />
+<polygon points='441.78,293.87 445.60,290.05 449.42,293.87 445.60,297.69 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU='>
+    <rect x='0.00' y='0.00' width='504.00' height='471.85' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU=)'>
+<text x='266.40' y='453.13' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='23.71px' lengthAdjust='spacingAndGlyphs'>Day</text>
+<text transform='translate(12.96,228.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='31.99px' lengthAdjust='spacingAndGlyphs'>Temp</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/aesthetics_type_b_lty.svg
+++ b/inst/tinytest/_tinysnapshot/aesthetics_type_b_lty.svg
@@ -1,0 +1,375 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='155.50' y='458.56' width='221.80' height='44.28' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='158.74' y1='488.08' x2='180.34' y2='488.08' style='stroke-width: 0.75;' />
+<line x1='202.02' y1='488.08' x2='223.62' y2='488.08' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='245.30' y1='488.08' x2='266.90' y2='488.08' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='288.58' y1='488.08' x2='310.18' y2='488.08' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='331.86' y1='488.08' x2='353.46' y2='488.08' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<circle cx='169.54' cy='488.08' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='212.82' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='256.10' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='299.38' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='342.66' cy='488.08' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<text x='266.40' y='473.32' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='37.63px' lengthAdjust='spacingAndGlyphs'>Month</text>
+<text x='191.14' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='234.42' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='277.70' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='320.98' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='364.26' y='492.45' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>9</text>
+<line x1='61.60' y1='398.41' x2='445.60' y2='398.41' style='stroke-width: 0.75;' />
+<line x1='61.60' y1='398.41' x2='61.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='125.60' y1='398.41' x2='125.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='189.60' y1='398.41' x2='189.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='253.60' y1='398.41' x2='253.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='317.60' y1='398.41' x2='317.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='381.60' y1='398.41' x2='381.60' y2='405.61' style='stroke-width: 0.75;' />
+<line x1='445.60' y1='398.41' x2='445.60' y2='405.61' style='stroke-width: 0.75;' />
+<text x='61.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='125.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='7.64px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='189.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='253.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='317.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='381.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='445.60' y='424.33' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>30</text>
+<line x1='59.04' y1='355.19' x2='59.04' y2='125.26' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='355.19' x2='51.84' y2='355.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='278.54' x2='51.84' y2='278.54' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='201.90' x2='51.84' y2='201.90' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='125.26' x2='51.84' y2='125.26' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,355.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,278.54) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text transform='translate(41.76,201.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,125.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='15.28px' lengthAdjust='spacingAndGlyphs'>90</text>
+<polygon points='59.04,398.41 473.76,398.41 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ=='>
+    <rect x='59.04' y='59.04' width='414.72' height='339.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+<line x1='76.68' y1='294.71' x2='84.92' y2='270.04' style='stroke-width: 0.75;' />
+<line x1='91.81' y1='257.69' x2='95.39' y2='253.41' style='stroke-width: 0.75;' />
+<line x1='100.99' y1='255.02' x2='111.81' y2='332.73' style='stroke-width: 0.75;' />
+<line x1='114.73' y1='346.79' x2='123.67' y2='378.91' style='stroke-width: 0.75;' />
+<line x1='126.79' y1='378.74' x2='137.21' y2='316.30' style='stroke-width: 0.75;' />
+<line x1='144.58' y1='312.90' x2='145.02' y2='313.17' style='stroke-width: 0.75;' />
+<line x1='153.13' y1='323.80' x2='162.07' y2='355.91' style='stroke-width: 0.75;' />
+<line x1='168.61' y1='357.32' x2='172.19' y2='353.05' style='stroke-width: 0.75;' />
+<line x1='178.27' y1='340.47' x2='188.13' y2='293.26' style='stroke-width: 0.75;' />
+<line x1='191.88' y1='279.38' x2='200.12' y2='254.72' style='stroke-width: 0.75;' />
+<line x1='204.68' y1='254.72' x2='212.92' y2='279.38' style='stroke-width: 0.75;' />
+<line x1='218.70' y1='292.50' x2='224.50' y2='302.91' style='stroke-width: 0.75;' />
+<line x1='232.61' y1='303.67' x2='236.19' y2='299.40' style='stroke-width: 0.75;' />
+<line x1='241.99' y1='300.97' x2='252.41' y2='363.41' style='stroke-width: 0.75;' />
+<line x1='255.53' y1='363.58' x2='264.47' y2='331.46' style='stroke-width: 0.75;' />
+<line x1='271.01' y1='319.00' x2='274.59' y2='314.73' style='stroke-width: 0.75;' />
+<line x1='280.51' y1='316.28' x2='290.69' y2='371.10' style='stroke-width: 0.75;' />
+<line x1='293.08' y1='371.06' x2='303.72' y2='300.99' style='stroke-width: 0.75;' />
+<line x1='306.73' y1='300.81' x2='315.67' y2='332.92' style='stroke-width: 0.75;' />
+<line x1='321.10' y1='346.15' x2='326.90' y2='356.56' style='stroke-width: 0.75;' />
+<line x1='331.25' y1='355.70' x2='342.35' y2='262.70' style='stroke-width: 0.75;' />
+<line x1='344.19' y1='262.68' x2='355.01' y2='340.39' style='stroke-width: 0.75;' />
+<line x1='371.57' y1='354.16' x2='378.83' y2='371.53' style='stroke-width: 0.75;' />
+<line x1='387.78' y1='374.48' x2='388.22' y2='374.21' style='stroke-width: 0.75;' />
+<line x1='400.58' y1='374.21' x2='401.02' y2='374.48' style='stroke-width: 0.75;' />
+<line x1='408.39' y1='371.08' x2='418.81' y2='308.64' style='stroke-width: 0.75;' />
+<line x1='420.85' y1='294.39' x2='431.95' y2='201.39' style='stroke-width: 0.75;' />
+<line x1='437.41' y1='199.76' x2='440.99' y2='204.04' style='stroke-width: 0.75;' />
+<line x1='449.10' y1='215.86' x2='454.90' y2='226.27' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='87.20' cy='263.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='100.00' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='112.80' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='125.60' cy='385.84' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='138.40' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.20' cy='316.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='164.00' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='176.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='189.60' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='247.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='215.20' cy='286.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='240.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='253.60' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='266.40' cy='324.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='279.20' cy='309.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='292.00' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='293.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='317.60' cy='339.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='362.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='343.20' cy='255.55' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='356.00' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='368.80' cy='347.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='394.40' cy='370.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='407.20' cy='378.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='420.00' cy='301.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='432.80' cy='194.24' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='445.60' cy='209.57' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='232.56' r='2.70' style='stroke-width: 0.75;' />
+<line x1='77.17' y1='223.87' x2='84.43' y2='241.24' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='88.87' y1='254.89' x2='98.33' y2='294.53' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='100.70' y1='294.37' x2='112.10' y2='178.41' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='118.98' y1='167.55' x2='119.42' y2='167.28' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='127.53' y1='170.52' x2='136.47' y2='202.63' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='141.90' y1='203.27' x2='147.70' y2='192.86' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='153.48' y1='179.74' x2='161.72' y2='155.08' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='167.50' y1='141.96' x2='173.30' y2='131.55' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='180.30' y1='131.55' x2='186.10' y2='141.96' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='191.53' y1='141.32' x2='200.47' y2='109.20' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='208.58' y1='105.96' x2='209.02' y2='106.23' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='216.39' y1='117.03' x2='226.81' y2='179.47' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='268.68' y1='231.72' x2='276.92' y2='256.39' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='280.87' y1='270.22' x2='290.33' y2='309.86' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='293.47' y1='309.82' x2='303.33' y2='262.60' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='308.30' y1='249.26' x2='314.10' y2='238.85' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='323.78' y1='228.86' x2='324.22' y2='228.59' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='336.58' y1='228.59' x2='337.02' y2='228.86' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='374.98' y1='236.26' x2='375.42' y2='236.52' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='385.10' y1='233.93' x2='390.90' y2='223.52' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='396.68' y1='224.06' x2='404.92' y2='248.72' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='408.87' y1='248.55' x2='418.33' y2='208.90' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='423.50' y1='208.19' x2='429.30' y2='218.60' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<line x1='434.73' y1='217.96' x2='443.67' y2='185.84' style='stroke-width: 0.75; stroke: #E69F00; stroke-dasharray: 4.00,4.00;' />
+<circle cx='74.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='87.20' cy='247.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='100.00' cy='301.54' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='112.80' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='125.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='138.40' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='151.20' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='164.00' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='176.80' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='189.60' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='202.40' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='215.20' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='228.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='240.80' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='253.60' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='266.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='279.20' cy='263.21' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='292.00' cy='316.86' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='304.80' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='317.60' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='330.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='343.20' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='356.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='368.80' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='381.60' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='394.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='407.20' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='420.00' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='432.80' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<circle cx='445.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #E69F00;' />
+<line x1='80.58' y1='167.55' x2='81.02' y2='167.28' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='89.97' y1='170.22' x2='97.23' y2='187.59' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='103.50' y1='187.95' x2='109.30' y2='177.53' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='118.98' y1='174.94' x2='119.42' y2='175.21' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='140.68' y1='172.08' x2='148.92' y2='147.42' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='153.97' y1='133.94' x2='161.23' y2='116.57' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='180.30' y1='116.22' x2='186.10' y2='126.63' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='191.27' y1='139.93' x2='200.73' y2='179.57' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='203.71' y1='193.65' x2='213.89' y2='248.47' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='216.67' y1='248.50' x2='226.53' y2='201.28' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='229.19' y1='187.14' x2='239.61' y2='124.70' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='241.88' y1='124.71' x2='252.52' y2='194.78' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='259.78' y1='198.20' x2='260.22' y2='197.94' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='272.58' y1='190.54' x2='273.02' y2='190.27' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='283.81' y1='181.05' x2='287.39' y2='176.77' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='295.50' y1='164.95' x2='301.30' y2='154.54' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='309.41' y1='153.78' x2='312.99' y2='158.05' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='318.68' y1='170.70' x2='329.32' y2='240.77' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='332.07' y1='240.88' x2='341.53' y2='201.24' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='349.38' y1='190.54' x2='349.82' y2='190.27' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='358.77' y1='179.93' x2='366.03' y2='162.56' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='374.98' y1='159.61' x2='375.42' y2='159.88' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='385.10' y1='169.87' x2='390.90' y2='180.28' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='397.17' y1='179.93' x2='404.43' y2='162.56' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='411.81' y1='150.39' x2='415.39' y2='146.11' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='424.61' y1='146.11' x2='428.19' y2='150.39' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='436.30' y1='162.21' x2='442.10' y2='172.62' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<line x1='450.21' y1='184.43' x2='453.79' y2='188.71' style='stroke-width: 0.75; stroke: #56B4E9; stroke-dasharray: 1.00,3.00;' />
+<circle cx='74.40' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='87.20' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='100.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='112.80' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='125.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='138.40' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='151.20' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='164.00' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='176.80' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='189.60' cy='132.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='202.40' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='215.20' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='228.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='240.80' cy='117.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='253.60' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='266.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='279.20' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='292.00' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='304.80' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='317.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='330.40' cy='247.89' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='343.20' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='356.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='368.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='381.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='394.40' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='407.20' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='420.00' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='432.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='445.60' cy='178.91' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<circle cx='458.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #56B4E9;' />
+<line x1='93.38' y1='190.54' x2='93.82' y2='190.27' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='102.77' y1='179.93' x2='110.03' y2='162.56' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='118.98' y1='159.61' x2='119.42' y2='159.88' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='130.21' y1='158.05' x2='133.79' y2='153.78' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='143.01' y1='142.72' x2='146.59' y2='138.45' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='157.38' y1='129.22' x2='157.82' y2='128.96' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='181.41' y1='119.73' x2='184.99' y2='115.46' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='191.53' y1='116.87' x2='200.47' y2='148.98' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='217.97' y1='162.56' x2='225.23' y2='179.93' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='232.61' y1='192.10' x2='236.19' y2='196.37' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='246.98' y1='205.60' x2='247.42' y2='205.87' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='258.21' y1='215.09' x2='261.79' y2='219.37' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='271.01' y1='219.37' x2='274.59' y2='215.09' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='282.70' y1='215.86' x2='288.50' y2='226.27' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='296.61' y1='227.03' x2='300.19' y2='222.76' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='323.78' y1='220.93' x2='324.22' y2='221.19' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='332.68' y1='231.72' x2='340.92' y2='256.39' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='346.70' y1='256.92' x2='352.50' y2='246.51' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='358.77' y1='233.58' x2='366.03' y2='216.21' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='373.41' y1='204.04' x2='376.99' y2='199.76' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='383.88' y1='187.41' x2='392.12' y2='162.74' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='399.01' y1='150.39' x2='402.59' y2='146.11' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='408.51' y1='133.51' x2='418.69' y2='78.69' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='423.50' y1='77.90' x2='429.30' y2='88.31' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='437.41' y1='89.08' x2='440.99' y2='84.80' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<line x1='450.21' y1='84.80' x2='453.79' y2='89.08' style='stroke-width: 0.75; stroke: #009E73; stroke-dasharray: 1.00,3.00,4.00,3.00;' />
+<circle cx='74.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='87.20' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='100.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='112.80' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='125.60' cy='163.58' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='138.40' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='151.20' cy='132.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='164.00' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='176.80' cy='125.26' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='189.60' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='202.40' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='215.20' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='228.00' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='240.80' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='253.60' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='266.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='279.20' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='292.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='304.80' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='317.60' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='330.40' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='343.20' cy='263.21' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='356.00' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='368.80' cy='209.57' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='381.60' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='394.40' cy='155.92' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='407.20' cy='140.59' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='420.00' cy='71.61' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='432.80' cy='94.60' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='445.60' cy='79.27' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<circle cx='458.40' cy='94.60' r='2.70' style='stroke-width: 0.75; stroke: #009E73;' />
+<line x1='80.58' y1='113.90' x2='81.02' y2='113.63' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='93.38' y1='106.23' x2='93.82' y2='105.96' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='114.73' y1='109.20' x2='123.67' y2='141.32' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='129.10' y1='154.54' x2='134.90' y2='164.95' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='141.17' y1='177.89' x2='148.43' y2='195.26' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='155.81' y1='207.43' x2='159.39' y2='211.70' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='167.50' y1='223.52' x2='173.30' y2='233.93' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='181.41' y1='245.75' x2='184.99' y2='250.02' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='191.07' y1='248.50' x2='200.93' y2='201.28' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='204.68' y1='201.07' x2='212.92' y2='225.73' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='221.38' y1='228.86' x2='221.82' y2='228.59' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='229.93' y1='231.83' x2='238.87' y2='263.94' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='255.27' y1='263.88' x2='264.73' y2='224.23' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='267.48' y1='224.35' x2='278.12' y2='294.42' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='280.51' y1='294.46' x2='290.69' y2='239.64' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='293.47' y1='239.61' x2='303.33' y2='286.82' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='305.65' y1='286.72' x2='316.75' y2='193.72' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='318.27' y1='193.74' x2='329.73' y2='317.36' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='332.07' y1='317.52' x2='341.53' y2='277.88' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='344.39' y1='263.78' x2='354.81' y2='201.34' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='356.99' y1='201.37' x2='367.81' y2='279.08' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='370.73' y1='293.14' x2='379.67' y2='325.26' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='383.27' y1='325.19' x2='392.73' y2='285.55' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='396.07' y1='271.54' x2='405.53' y2='231.90' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='411.81' y1='230.42' x2='415.39' y2='234.70' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='426.18' y1='236.52' x2='426.62' y2='236.26' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<line x1='434.27' y1='239.61' x2='444.13' y2='286.82' style='stroke-width: 0.75; stroke: #F0E442; stroke-dasharray: 7.00,3.00;' />
+<circle cx='74.40' cy='117.59' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='87.20' cy='109.93' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='100.00' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='112.80' cy='102.27' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='125.60' cy='148.25' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='138.40' cy='171.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='151.20' cy='201.90' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='164.00' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='176.80' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='189.60' cy='255.55' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='202.40' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='215.20' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='228.00' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='240.80' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='253.60' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='266.40' cy='217.23' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='279.20' cy='301.54' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='292.00' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='304.80' cy='293.87' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='317.60' cy='186.57' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='330.40' cy='324.53' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='343.20' cy='270.88' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='356.00' cy='194.24' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='368.80' cy='286.21' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='381.60' cy='332.19' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='394.40' cy='278.54' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='407.20' cy='224.89' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='420.00' cy='240.22' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='432.80' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+<circle cx='445.60' cy='293.87' r='2.70' style='stroke-width: 0.75; stroke: #F0E442;' />
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU='>
+    <rect x='0.00' y='0.00' width='504.00' height='471.85' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw0NzEuODU=)'>
+<text x='266.40' y='453.13' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='23.71px' lengthAdjust='spacingAndGlyphs'>Day</text>
+<text transform='translate(12.96,228.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Arimo";' textLength='31.99px' lengthAdjust='spacingAndGlyphs'>Temp</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDM5OC40MQ==)'>
+</g>
+</svg>

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -1,0 +1,3 @@
+library(tinytest)
+library(tinysnapshot)
+options("tinysnapshot_device" = "svglite")

--- a/inst/tinytest/test-aesthetics.R
+++ b/inst/tinytest/test-aesthetics.R
@@ -1,0 +1,13 @@
+source("helpers.R")
+using("tinysnapshot")
+if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
+
+# type="b" + aesthetics
+f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b")
+expect_snapshot_plot(f, label = "aesthetics_type_b")
+
+f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", lty = 1:5)
+expect_snapshot_plot(f, label = "aesthetics_type_b_lty")
+
+f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", col = 1, pch = 1:5)
+expect_snapshot_plot(f, label = "aesthetics_type_b_col_pch")

--- a/inst/tinytest/test_plot2.R
+++ b/inst/tinytest/test_plot2.R
@@ -1,4 +1,0 @@
-
-# Placeholder with simple test
-expect_equal(1 + 1, 2)
-

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -31,6 +31,8 @@ plot2(x, ...)
   legend.position = NULL,
   legend.args = list(),
   pch = NULL,
+  col = NULL,
+  lty = NULL,
   ...
 )
 
@@ -54,6 +56,8 @@ plot2(x, ...)
   legend.position = NULL,
   legend.args = list(),
   pch = NULL,
+  col = NULL,
+  lty = NULL,
   formula = NULL,
   subset = NULL,
   na.action = NULL,
@@ -130,7 +134,11 @@ legend is desired, then the user can also specify "none".}
 \item{legend.args}{list of additional arguments passed on to `legend`. At
 the moment, only "bty", "horiz", "xpd", and "title" are supported.}
 
-\item{pch}{plotting "character", i.e., symbol to use. See `pch`.}
+\item{pch}{plotting "character", i.e., symbol to use. Character, integer, or vector of length equal to the number of categories in the `by` variable. See `pch`.}
+
+\item{col}{plotting color. Character, integer, or vector of length equal to the number of categories in the `by` variable. See `col`.}
+
+\item{lty}{line type. Character, integer, or vector of length equal to the number of categories in the `by` variable. See `lty`.}
 
 \item{formula}{a `formula` that may also include a grouping variable after a
 "|", such as `y ~ x | z`. Note that the `formula` and `x` arguments should


### PR DESCRIPTION
This PR includes a minimal `tinysnapshot` setup and a few tests. You can change the `exit_file` call at the top of the file if you intend to re-generate snapshots on `"Darwin"`.

This PR allows users to specify `lty`, `col`, and `pch` by group. One nice benefit is that we can use the `col` argument to do black and white figures. For example:

``` r
library(plot2)

plot2(Temp ~ Day | Month, type = "b",
    data = subset(airquality, Month %in% 5:7),
    pch = 1:3, col = "black", lty = 1:3)
```

![](https://i.imgur.com/biIJ79z.png)
