### PR TITLE
tinytest 0.0.3 is now on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Authors@R:
       comment = c(ORCID = "0000-0003-0918-3766")
      )
   )
-Remotes: vincentarelbundock/tinysnapshot
 Description: Lightweight extension of the base R plot function, with support for
       automatic grouping and legend printing, and several other enhancements.
 License: GPL (>= 2) 
@@ -42,7 +41,7 @@ Suggests:
   rsvg,
   svglite,
   tinysnapshot,
-  tinytest
+  tinytest (>= 0.0.3)
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 URL: https://grantmcdermott.com/plot2/,

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -1,4 +1,5 @@
 library(tinytest)
 library(tinysnapshot)
+options("tinysnapshot_os" = "Linux")
 options("tinysnapshot_device" = "svglite")
 options("tinysnapshot_device_args" = list(user_fonts = fontquiver::font_families("Liberation")))

--- a/inst/tinytest/test-README.R
+++ b/inst/tinytest/test-README.R
@@ -1,6 +1,5 @@
 source("helpers.R")
 using("tinysnapshot")
-if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
 
 op = par(no.readonly = TRUE)
 

--- a/inst/tinytest/test-misc.R
+++ b/inst/tinytest/test-misc.R
@@ -1,6 +1,5 @@
 source("helpers.R")
 using("tinysnapshot")
-if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
 
 f = function() {
   par(mfrow = c(1, 2))

--- a/inst/tinytest/test-par_restore.R
+++ b/inst/tinytest/test-par_restore.R
@@ -1,6 +1,5 @@
 source("helpers.R")
 using("tinysnapshot")
-if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
 
 op = par(no.readonly = TRUE)
 


### PR DESCRIPTION
No longer need it in `Remotes:`