### PR TITLE
Unified palette arg

### DIFF
--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -1,58 +1,70 @@
-by_col = function(ngrps, col = NULL, palette = NULL, palette.args = NULL) {
+by_col = function(ngrps = 1L, col = NULL, palette = NULL) {
   
-  if (is.null(col)) {
+  # palette = substitute(palette, env = parent.env(environment()))
+  
+  if (is.null(col) && is.null(palette)) {
     col = seq_len(ngrps)
   }
-
+  
   if (is.atomic(col) && is.vector(col)) {
     if (length(col) == 1) {
-        col = rep(col, ngrps)
+      col = rep(col, ngrps)
     } else if (length(col) != ngrps) {
-        stop(sprintf("`col` must be of length 1 or %s.", ngrps), call. = FALSE)
+      stop(sprintf("`col` must be of length 1 or %s.", ngrps), call. = FALSE)
     }
-    if (is.character(col)) return(col)
-  }
-
-  if (is.null(palette)) {
-    if (ngrps<=9) {
-      palette = "Okabe-Ito"
-      palette_fun = palette.colors
-    } else {
-      palette = "Viridis"
-      palette_fun = hcl.colors
-    }
-  } else if (palette %in% palette.pals()) {
-    palette_fun = palette.colors
-  } else if (palette %in% hcl.pals()) {
-    palette_fun = hcl.colors
-  } else {
-    warning(
-      "\nPalette string not recogized. Must be a value produced by either",
-      "`palette.pals()` or `hcl.pals()`.",
-      "\nUsing default option instead.\n",
-      call. = FALSE
-      )
-    if (ngrps <= 9) {
-      palette = "Okabe-Ito"
-      palette_fun = palette.colors
-    } else {
-      palette = "Viridis"
-      palette_fun = hcl.colors
+    if (is.character(col)) {
+      return(col)
     }
   }
-
-  # n is a required argument for viridis and other palettes
-  if (!"n" %in% names(palette.args)) palette.args[["n"]] = max(col)
-
-  out = do.call(
-    function(...) Map(palette_fun, palette = palette, ...), 
-    args = palette.args
-    )[[1]]
   
-  out = out[col]
- 
-  return(out)
-
+  if (is.null(palette)) {
+    
+    if (ngrps<=8) {
+      palette = "Okabe-Ito" #"R4"
+      palette_fun = palette.colors
+    } else {
+      palette = "Viridis"
+      palette_fun = hcl.colors
+    }
+    args = list(n = ngrps, palette = palette)
+    
+  } else {
+    
+    if (class(palette)=="character") {
+      if (tolower(palette) %in% tolower(palette.pals())) {
+        palette_fun = palette.colors
+      } else if (tolower(palette) %in% tolower(hcl.pals())) {
+        palette_fun = hcl.colors
+      } else {
+        stop(
+          "\nPalette string not recogized. Must be a value produced by either",
+          "`palette.pals()` or `hcl.pals()`.\n",
+          call. = FALSE
+        )
+      }
+      args = list(n = ngrps, palette = palette)
+    } else if (class(palette) %in% c("call", "name")) {
+      args = as.list(palette)
+      palette_fun = paste(args[[1]])
+      args[[1]] = NULL
+      args[["n"]] = ngrps
+      # remove unnamed arguments to prevent unintentional argument sliding
+      if (any(names(args)=="")) args[[which(names(args)=="")]] = NULL
+    } else {
+      stop(
+        "\nInvalid palette argument. Must be a recognized keyword, or a",
+        "palette-generating function with named arguments.\n"
+        )
+    }
+  }
+  
+  cols = tryCatch(
+    do.call(palette_fun, args),
+    error = function(e) do.call(eval(palette), args) # catch for bespoke palette generating funcs
+  )
+  
+  return(cols)
+  
 }
 
 

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -30,7 +30,7 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL) {
     
   } else {
     
-    if (class(palette)=="character") {
+    if (is.character(palette)) {
       if (tolower(palette) %in% tolower(palette.pals())) {
         palette_fun = palette.colors
       } else if (tolower(palette) %in% tolower(hcl.pals())) {

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -50,12 +50,17 @@
 #'   replaces the `panel.first` and `panel.last` arguments from base `plot()`
 #'   and tries to make the process more seemless with better default behaviour.
 #' @param asp the y/xy/x aspect ratio, see `plot.window`.
-#' @param palette a string corresponding to one of the supported palettes
-#'   listed by either `palette.pals()` or `hcl.pals()`.
-#' @param palette.args list of additional arguments passed to either
-#'   `palette.colors()` or `hcl.colors`, depending on which string was passed
-#'   to the `palette` argument. For example, you might have "recycle = TRUE"
-#'   if using a `palette.colors` palette.
+#' @param palette one of the following options:
+#'    - NULL (default), in which case R's default colour palette will be used.
+#'    - A string corresponding to one of the palettes in either `palette.pals()`
+#'    `hcl.pals()`. These can be case-insensitive (e.g., "viridis" and "Viridis"
+#'    are both valid).
+#'    - A palette-generating function. This can be "bare" (e.g.,
+#'    `palette.colors`) or "closed" with a set of named arguments (e.g.,
+#'    `palette.colors(palette = "Okabe-Ito", alpha = 0.5)`). Note that any
+#'    unnamed arguments will be ignored and the key `n` argument, denoting the
+#'    number of colours, will automatically be spliced in as the number of
+#'    groups.
 #' @param legend.position one of the position keywords supported by `legend`.
 #'   In addition, `plot2` supports adding an exclamation point to two keywords
 #'   in particular: "bottom!" and "right!". These will place the legend outside
@@ -175,7 +180,7 @@
 #'   Temp ~ Day | Month,
 #'   data = airquality,
 #'   type = "b", pch = 16,
-#'   palette = "Tableau 10", palette.args = list(alpha = 0.5),
+#'   palette = palette.colors(palette = "Tableau 10", alpha = 0.5),
 #'   main = "Daily temperatures by month",
 #'   frame.plot = FALSE, grid = grid()
 #' )
@@ -225,7 +230,6 @@ plot2.default = function(
     asp = NA,
     grid = NULL,
     palette = NULL,
-    palette.args = list(),
     legend.position = NULL,
     legend.args = list(),
     pch = NULL,
@@ -260,11 +264,12 @@ plot2.default = function(
   
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
 
+  # palette = substitute(palette)
   col = by_col(
     ngrps = ngrps,
     col = col,
-    palette = palette,
-    palette.args = palette.args)
+    palette = substitute(palette)
+    )
   
   # Save current graphical parameters
   opar = par(no.readonly = TRUE)
@@ -456,8 +461,7 @@ plot2.formula = function(
     frame.plot = axes,
     asp = NA,
     grid = NULL,
-    palette = NULL,
-    palette.args = list(),
+    # palette = NULL,
     legend.position = NULL,
     legend.args = list(),
     pch = NULL,
@@ -537,8 +541,7 @@ plot2.formula = function(
     frame.plot = frame.plot,
     asp = asp,
     grid = grid,
-    palette = palette,
-    palette.args = palette.args,
+    # palette = palette,
     legend.position = legend.position,
     legend.args = legend.args,
     pch = pch,
@@ -570,8 +573,7 @@ plot2.density = function(
     frame.plot = axes,
     asp = NA,
     grid = NULL,
-    palette = NULL,
-    palette.args = list(),
+    # palette = NULL,
     legend.position = NULL,
     legend.args = list(),
     pch = NULL,
@@ -650,8 +652,7 @@ plot2.density = function(
     frame.plot = frame.plot,
     asp = asp,
     grid = grid,
-    palette = palette,
-    palette.args = palette.args,
+    # palette = palette,
     legend.position = legend.position,
     legend.args = legend.args,
     pch = pch,

--- a/README.Rmd
+++ b/README.Rmd
@@ -228,7 +228,7 @@ plot2(
   Temp ~ Day | Month,
   data = airquality,
   type = "b",
-  palette = "Tableau 10", palette.args = list(alpha = 0.5),
+  palette = palette.colors(palette = "Tableau 10", alpha = 0.5),
   main = "Daily temperatures by month",
   frame.plot = FALSE, grid = grid()
 )

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ plot2(
   Temp ~ Day | Month,
   data = airquality,
   type = "b",
-  palette = "Tableau 10", palette.args = list(alpha = 0.5),
+  palette = palette.colors(palette = "Tableau 10", alpha = 0.5),
   main = "Daily temperatures by month",
   frame.plot = FALSE, grid = grid()
 )

--- a/inst/tinytest/test-README.R
+++ b/inst/tinytest/test-README.R
@@ -105,7 +105,7 @@ f = function() {
     Temp ~ Day | Month,
     data = airquality,
     type = "b",
-    palette = "Tableau 10", palette.args = list(alpha = 0.5),
+    palette = palette.colors(palette = "Tableau 10", alpha = 0.5),
     main = "Daily temperatures by month",
     frame.plot = FALSE, grid = grid()
   )

--- a/inst/tinytest/test-aesthetics.R
+++ b/inst/tinytest/test-aesthetics.R
@@ -15,7 +15,7 @@ expect_snapshot_plot(f, label = "aesthetics_type_b")
 f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", lty = 1:5)
 expect_snapshot_plot(f, label = "aesthetics_type_b_lty")
 
-f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", col = 1, pch = 1:5)
+f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", col = "black", pch = 1:5)
 expect_snapshot_plot(f, label = "aesthetics_type_b_col_pch")
 
 # check that non-point types don't generate points accidentally
@@ -34,7 +34,7 @@ f = function() plot2(Temp ~ Day | Month, data = airquality, type = "l", pch = "b
 expect_snapshot_plot(f, label = "aesthetics_by_type_l")
 
 # no color version
-f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", pch = "by", lty = "by", col = 1)
+f = function() plot2(Temp ~ Day | Month, data = airquality, type = "b", pch = "by", lty = "by", col = "black")
 expect_snapshot_plot(f, label = "aesthetics_by_nocol")
 
 # inherit global par

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -28,7 +28,6 @@ plot2(x, ...)
   asp = NA,
   grid = NULL,
   palette = NULL,
-  palette.args = list(),
   legend.position = NULL,
   legend.args = list(),
   pch = NULL,
@@ -53,8 +52,6 @@ plot2(x, ...)
   frame.plot = axes,
   asp = NA,
   grid = NULL,
-  palette = NULL,
-  palette.args = list(),
   legend.position = NULL,
   legend.args = list(),
   pch = NULL,
@@ -83,8 +80,6 @@ plot2(x, ...)
   frame.plot = axes,
   asp = NA,
   grid = NULL,
-  palette = NULL,
-  palette.args = list(),
   legend.position = NULL,
   legend.args = list(),
   pch = NULL,
@@ -150,13 +145,17 @@ the plot.}
 replaces the `panel.first` and `panel.last` arguments from base `plot()`
 and tries to make the process more seemless with better default behaviour.}
 
-\item{palette}{a string corresponding to one of the supported palettes
-listed by either `palette.pals()` or `hcl.pals()`.}
-
-\item{palette.args}{list of additional arguments passed to either
-`palette.colors()` or `hcl.colors`, depending on which string was passed
-to the `palette` argument. For example, you might have "recycle = TRUE"
-if using a `palette.colors` palette.}
+\item{palette}{one of the following options:
+- NULL (default), in which case R's default colour palette will be used.
+- A string corresponding to one of the palettes in either `palette.pals()`
+`hcl.pals()`. These can be case-insensitive (e.g., "viridis" and "Viridis"
+are both valid).
+- A palette-generating function. This can be "bare" (e.g.,
+`palette.colors`) or "closed" with a set of named arguments (e.g.,
+`palette.colors(palette = "Okabe-Ito", alpha = 0.5)`). Note that any
+unnamed arguments will be ignored and the key `n` argument, denoting the
+number of colours, will automatically be spliced in as the number of
+groups.}
 
 \item{legend.position}{one of the position keywords supported by `legend`.
 In addition, `plot2` supports adding an exclamation point to two keywords
@@ -294,7 +293,7 @@ plot2(
   Temp ~ Day | Month,
   data = airquality,
   type = "b", pch = 16,
-  palette = "Tableau 10", palette.args = list(alpha = 0.5),
+  palette = palette.colors(palette = "Tableau 10", alpha = 0.5),
   main = "Daily temperatures by month",
   frame.plot = FALSE, grid = grid()
 )


### PR DESCRIPTION
Addresses the second part of #19 .

Some quick notes:

- I've left the default colour palette as Okabe-Ito for the moment to becnhmark against our existing test suite.
- I had to do some tricksy `substitute` footwork to get all eventualities covered, i.e. users can pass strings or functions, where we can still splice in the number of colours (groups) later on. Similarly, I also had to drop `palette` as an argument for `plot2.formula` and `plot2.density` and rather pass this through `...`. Otherwise `substitute` doesn’t work properly. Maybe there's a more failsafe way to do this?

Examples:

``` r
library(plot2)

plot2(
  Temp ~ Day | Month, airquality,
  type = "b", pch = 16
  )
```

![](https://i.imgur.com/JZNClDc.png)<!-- -->

``` r
plot2(
  Temp ~ Day | Month, airquality,
  type = "b", pch = 16,
  palette = "tableau 10"
  )
```

![](https://i.imgur.com/XiZ5MJj.png)<!-- -->

``` r
plot2(
  Temp ~ Day | Month, airquality,
  type = "b", pch = 16,
  palette = palette.colors(palette = "Tableau 10", alpha = 0.5)
  )
```

![](https://i.imgur.com/thiXnQ8.png)<!-- -->

``` r
plot2(
  Temp ~ Day | Month, airquality,
  type = "b", pch = 16,
  palette = khroma::color("muted")
  )
```

![](https://i.imgur.com/Ym0RQQ7.png)<!-- -->

<sup>Created on 2023-04-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>