### PR TITLE
Hard code "p" type

### DIFF
--- a/R/plot2.R
+++ b/R/plot2.R
@@ -432,7 +432,8 @@ plot2.default = function(
             x = split_data[[i]]$x,
             y = split_data[[i]]$y,
             col = col[i],
-            type = type,
+            # type = type, ## rather hardcode "p" to avoid warning message about "pointrange"
+            type = "p",
             pch = pch[i],
             lty = lty[i]
           )


### PR DESCRIPTION
Avoids the following message for pointrange plots:

```r
Warning message:
In plot.xy(xy.coords(x, y), type = type, ...) :
  plot type 'pointrange' will be truncated to first character
```