### PR TITLE
Support cex and bg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3
+Version: 0.0.3.9001
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# plot2 0.0.3.9000 (development version)
+# plot2 0.0.3.9001 (development version)
+
+New features:
+
+- Support for `cex` and `bg` arguments. The latter also permits the "by"
+convenience keyword similar to `lty` and `pch`. This is useful for plotting
+filled point characters (e.g., pch = 21), where you want a different colour for
+the fill and border. (#50 @grantmcdermott)
 
 # plot2 0.0.3
 

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -2,6 +2,9 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL) {
   
   # palette = substitute(palette, env = parent.env(environment()))
   
+  # special "by" convenience keyword (will treat as NULL & handle grouping below)
+  if (!is.null(col) && length(col)==1 && col=="by") col = NULL
+
   if (is.null(col) && is.null(palette)) {
     col = seq_len(ngrps)
   }

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -62,14 +62,16 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL) {
         )
     }
   }
-  
+
   cols = tryCatch(
     do.call(palette_fun, args),
     error = function(e) do.call(eval(palette), args) # catch for bespoke palette generating funcs
   )
-  
+
+  if (length(cols) > ngrps) cols = cols[1:ngrps]
+
   return(cols)
-  
+
 }
 
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -338,7 +338,6 @@ plot2.default = function(
   } else {
     bg = rep(bg, ngrps)
   }
-  cat("\n", bg, "\n")
   
   # Save current graphical parameters
   opar = par(no.readonly = TRUE)

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -90,20 +90,30 @@
 #'    specifying "none").
 #'    - A list or, equivalently, a dedicated `legend()` function with supported
 #'    legend arguments, e.g. "bty", "horiz", and so forth.
+#' @param col plotting color. Character, integer, or vector of length equal to
+#'   the number of categories in the `by` variable. See `col`. Specifying colors
+#'   manually in `plot2` should not be necessary unless users wish to override
+#'   the automatic colors produced by the grouping process. Typically, this
+#'   would only be done if grouping characterists are deferred to some other
+#'   graphical parameter (i.e., passing the "by" keyword to one of `pch`, `lty`,
+#'   or `bg`; see below.)
 #' @param pch plotting "character", i.e., symbol to use. Character, integer, or
 #'   vector of length equal to the number of categories in the `by` variable.
 #'   See `pch`. In addition, users can supply a special `pch = "by"` convenience
 #'   argument, in which case the characters will automatically loop over the
 #'   number groups. This automatic looping will begin at the global character
 #'   value (i.e., `par("pch")`) and recycle as necessary.
-#' @param col plotting color. Character, integer, or vector of length equal to
-#'   the number of categories in the `by` variable. See `col`.
 #' @param lty line type. Character, integer, or vector of length equal to the
 #'   number of categories in the `by` variable. See `lty`. In addition, users
 #'   can supply a special `lty = "by"` convenience argument, in which case the
 #'   line type will automatically loop over the number groups. This automatic
 #'   looping will begin at the global line type value (i.e., `par("lty")`) and
 #'   recycle as necessary.
+#' @param bg background (fill) color for the open plot symbols 21:25: see
+#'   `points.default`. In addition, users can supply a special `bg = "by"`
+#'   convenience argument, in which case the background color will inherit the
+#'   automatic group coloring intended for the `col` parameter.
+#' @param cex character expansion.
 #' @param par_restore a logical value indicating whether the `par` settings
 #'   prior to calling `plot2` should be restored on exit. Defaults to FALSE,
 #'   which makes it possible to add elements to the plot after it has been
@@ -256,8 +266,10 @@ plot2.default = function(
     palette = NULL,
     legend = NULL,
     pch = NULL,
-    col = NULL,
     lty = NULL,
+    col = NULL,
+    bg = NA,
+    cex = 1,
     par_restore = FALSE,
     ymin = NULL,
     ymax = NULL,
@@ -316,7 +328,17 @@ plot2.default = function(
     ngrps = ngrps,
     col = col,
     palette = substitute(palette)
+  )
+  if (!is.na(bg) && bg == "by") {
+    bg = by_col(
+      ngrps = ngrps,
+      col = NULL,
+      palette = substitute(palette)
     )
+  } else {
+    bg = rep(bg, ngrps)
+  }
+  cat("\n", bg, "\n")
   
   # Save current graphical parameters
   opar = par(no.readonly = TRUE)
@@ -372,6 +394,14 @@ plot2.default = function(
   if (is.null(legend.args[["bty"]])) legend.args[["bty"]] = "n"
   if (is.null(legend.args[["horiz"]])) legend.args[["horiz"]] = FALSE
   if (is.null(legend.args[["xpd"]])) legend.args[["xpd"]] = NA
+  if (is.null(legend.args[["pt.bg"]])) legend.args[["pt.bg"]] = bg
+  if (
+    type %in% c("p", "pointrange", "errorbar") &&
+      (length(col) == 1 || length(cex) == 1) &&
+      is.null(legend.args[["pt.cex"]])
+  ) {
+    legend.args[["pt.cex"]] = cex
+  }
   
   if (legend.args[["x"]] != "none") {
     
@@ -591,10 +621,12 @@ plot2.default = function(
             x = split_data[[i]]$x,
             y = split_data[[i]]$y,
             col = col[i],
+            bg = bg[i],
             # type = type, ## rather hardcode "p" to avoid warning message about "pointrange"
             type = "p",
             pch = pch[i],
-            lty = lty[i]
+            lty = lty[i],
+            cex = cex
           )
         }
       )

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -91,12 +91,13 @@
 #'    - A list or, equivalently, a dedicated `legend()` function with supported
 #'    legend arguments, e.g. "bty", "horiz", and so forth.
 #' @param col plotting color. Character, integer, or vector of length equal to
-#'   the number of categories in the `by` variable. See `col`. Specifying colors
-#'   manually in `plot2` should not be necessary unless users wish to override
-#'   the automatic colors produced by the grouping process. Typically, this
-#'   would only be done if grouping characterists are deferred to some other
-#'   graphical parameter (i.e., passing the "by" keyword to one of `pch`, `lty`,
-#'   or `bg`; see below.)
+#'   the number of categories in the `by` variable. See `col`. Note that the
+#'   default behaviour in `plot2` is to vary group colors along any variables
+#'   declared in the `by` argument. Thus, specifying colors manually should not
+#'   be necessary unless users wish to override the automatic colors produced by
+#'   this grouping process. Typically, this would only be done if grouping
+#'   features are deferred to some other graphical parameter (i.e., passing the
+#'   "by" keyword to one of `pch`, `lty`, or `bg`; see below.)
 #' @param pch plotting "character", i.e., symbol to use. Character, integer, or
 #'   vector of length equal to the number of categories in the `by` variable.
 #'   See `pch`. In addition, users can supply a special `pch = "by"` convenience
@@ -113,7 +114,10 @@
 #'   `points.default`. In addition, users can supply a special `bg = "by"`
 #'   convenience argument, in which case the background color will inherit the
 #'   automatic group coloring intended for the `col` parameter.
-#' @param cex character expansion.
+#' @param cex character expansion. A numerical vector (can be a single value)
+#'   giving the amount by which plotting characters and symbols should be scaled
+#'   relative to the default. Note that NULL is equivalent to 1.0, while NA
+#'   renders the characters invisible.
 #' @param par_restore a logical value indicating whether the `par` settings
 #'   prior to calling `plot2` should be restored on exit. Defaults to FALSE,
 #'   which makes it possible to add elements to the plot after it has been
@@ -268,7 +272,7 @@ plot2.default = function(
     pch = NULL,
     lty = NULL,
     col = NULL,
-    bg = NA,
+    bg = NULL,
     cex = 1,
     par_restore = FALSE,
     ymin = NULL,
@@ -329,7 +333,7 @@ plot2.default = function(
     col = col,
     palette = substitute(palette)
   )
-  if (!is.na(bg) && bg == "by") {
+  if (!is.null(bg) && bg == "by") {
     bg = by_col(
       ngrps = ngrps,
       col = NULL,

--- a/man/plot2-package.Rd
+++ b/man/plot2-package.Rd
@@ -30,7 +30,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Grant McDermott \email{grantmcd@uoregon.edu}
+\strong{Maintainer}: Grant McDermott \email{gmcd@amazon.com}
 
 Authors:
 \itemize{

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -32,7 +32,7 @@ plot2(x, ...)
   pch = NULL,
   lty = NULL,
   col = NULL,
-  bg = NA,
+  bg = NULL,
   cex = 1,
   par_restore = FALSE,
   ymin = NULL,
@@ -208,19 +208,23 @@ looping will begin at the global line type value (i.e., \code{par("lty")}) and
 recycle as necessary.}
 
 \item{col}{plotting color. Character, integer, or vector of length equal to
-the number of categories in the \code{by} variable. See \code{col}. Specifying colors
-manually in \code{plot2} should not be necessary unless users wish to override
-the automatic colors produced by the grouping process. Typically, this
-would only be done if grouping characterists are deferred to some other
-graphical parameter (i.e., passing the "by" keyword to one of \code{pch}, \code{lty},
-or \code{bg}; see below.)}
+the number of categories in the \code{by} variable. See \code{col}. Note that the
+default behaviour in \code{plot2} is to vary group colors along any variables
+declared in the \code{by} argument. Thus, specifying colors manually should not
+be necessary unless users wish to override the automatic colors produced by
+this grouping process. Typically, this would only be done if grouping
+features are deferred to some other graphical parameter (i.e., passing the
+"by" keyword to one of \code{pch}, \code{lty}, or \code{bg}; see below.)}
 
 \item{bg}{background (fill) color for the open plot symbols 21:25: see
 \code{points.default}. In addition, users can supply a special \code{bg = "by"}
 convenience argument, in which case the background color will inherit the
 automatic group coloring intended for the \code{col} parameter.}
 
-\item{cex}{character expansion.}
+\item{cex}{character expansion. A numerical vector (can be a single value)
+giving the amount by which plotting characters and symbols should be scaled
+relative to the default. Note that NULL is equivalent to 1.0, while NA
+renders the characters invisible.}
 
 \item{par_restore}{a logical value indicating whether the \code{par} settings
 prior to calling \code{plot2} should be restored on exit. Defaults to FALSE,

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -30,8 +30,10 @@ plot2(x, ...)
   palette = NULL,
   legend = NULL,
   pch = NULL,
-  col = NULL,
   lty = NULL,
+  col = NULL,
+  bg = NA,
+  cex = 1,
   par_restore = FALSE,
   ymin = NULL,
   ymax = NULL,
@@ -198,15 +200,27 @@ argument, in which case the characters will automatically loop over the
 number groups. This automatic looping will begin at the global character
 value (i.e., \code{par("pch")}) and recycle as necessary.}
 
-\item{col}{plotting color. Character, integer, or vector of length equal to
-the number of categories in the \code{by} variable. See \code{col}.}
-
 \item{lty}{line type. Character, integer, or vector of length equal to the
 number of categories in the \code{by} variable. See \code{lty}. In addition, users
 can supply a special \code{lty = "by"} convenience argument, in which case the
 line type will automatically loop over the number groups. This automatic
 looping will begin at the global line type value (i.e., \code{par("lty")}) and
 recycle as necessary.}
+
+\item{col}{plotting color. Character, integer, or vector of length equal to
+the number of categories in the \code{by} variable. See \code{col}. Specifying colors
+manually in \code{plot2} should not be necessary unless users wish to override
+the automatic colors produced by the grouping process. Typically, this
+would only be done if grouping characterists are deferred to some other
+graphical parameter (i.e., passing the "by" keyword to one of \code{pch}, \code{lty},
+or \code{bg}; see below.)}
+
+\item{bg}{background (fill) color for the open plot symbols 21:25: see
+\code{points.default}. In addition, users can supply a special \code{bg = "by"}
+convenience argument, in which case the background color will inherit the
+automatic group coloring intended for the \code{col} parameter.}
+
+\item{cex}{character expansion.}
 
 \item{par_restore}{a logical value indicating whether the \code{par} settings
 prior to calling \code{plot2} should be restored on exit. Defaults to FALSE,


### PR DESCRIPTION
Closes #48. Closes #49.

In addition to specifying these parameters manually, this PR also permits `bg = "by"` (similar to existing "by" keyword support for `lty` and `pch`).

I haven't added `cex = "by"` keword support yet, because I need to solve the potential problem of dual legend placement, e.g. one legend for colors and another for cex/size. However, once that's been cracked then it should be fairly trivial to support "bubble" plot types (c.f., #29).

Quick example of what this PR allows:

``` r
library(plot2)

palette("Tableau 10")
palette(adjustcolor(palette() , 0.3))

plot2(
    Sepal.Length ~ Petal.Length | Species, iris,
    pch = 21,
    col = "black",
    bg = "by",
    cex = 2
)
```

![](https://i.imgur.com/2KFbiZd.png)<!-- -->

<sup>Created on 2023-07-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>