### PR TITLE
Fix y-title for function names

### DIFF
--- a/R/plot2.R
+++ b/R/plot2.R
@@ -281,14 +281,22 @@ plot2.default = function(
   
   dots = list(...)
   
+  # Captured deparsed expressions early, before x and y are evaluated
+  x_dep = deparse(substitute(x))
+  y_dep = if (is.null(y)) {
+    deparse(substitute(x))
+  } else {
+    deparse(substitute(y))
+  }
+  
   if (is.null(y)) {
     y = x
     x = seq_along(x)
     xlab = "Index"
-    }
+  }
   
-  if (is.null(xlab)) xlab = deparse(substitute(x))
-  if (is.null(ylab)) ylab = deparse(substitute(y))
+  if (is.null(xlab)) xlab = x_dep
+  if (is.null(ylab)) ylab = y_dep
     
   xlabs = NULL
   if (type %in% c("pointrange", "errorbar", "ribbon")) {

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -281,7 +281,7 @@ plot2.default = function(
   
   dots = list(...)
   
-  # Captured deparsed expressions early, before x and y are evaluated
+  # Capture deparsed expressions early, before x and y are evaluated
   x_dep = deparse(substitute(x))
   y_dep = if (is.null(y)) {
     deparse(substitute(x))

--- a/inst/tinytest/test-label.R
+++ b/inst/tinytest/test-label.R
@@ -1,0 +1,14 @@
+source("helpers.R")
+using("tinysnapshot")
+# if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
+
+op = par(no.readonly = TRUE)
+
+f = function() {
+  set.seed(42)
+  plot2(rnorm(1))
+} 
+expect_snapshot_plot(f, label = "ylab_good")
+
+# reset par
+par(op)

--- a/inst/tinytest/test-label.R
+++ b/inst/tinytest/test-label.R
@@ -1,6 +1,6 @@
 source("helpers.R")
 using("tinysnapshot")
-# if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
+if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
 
 op = par(no.readonly = TRUE)
 

--- a/inst/tinytest/test-label.R
+++ b/inst/tinytest/test-label.R
@@ -1,14 +1,14 @@
-source("helpers.R")
-using("tinysnapshot")
-if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
-
-op = par(no.readonly = TRUE)
-
-f = function() {
-  set.seed(42)
-  plot2(rnorm(1))
-} 
-expect_snapshot_plot(f, label = "ylab_good")
-
-# reset par
-par(op)
+# source("helpers.R")
+# using("tinysnapshot")
+# if (Sys.info()["sysname"] != "Linux") exit_file("Linux snapshots")
+# 
+# op = par(no.readonly = TRUE)
+# 
+# f = function() {
+#   set.seed(42)
+#   plot2(rnorm(1))
+# } 
+# expect_snapshot_plot(f, label = "ylab_good")
+# 
+# # reset par
+# par(op)

--- a/inst/tinytest/test-label.R
+++ b/inst/tinytest/test-label.R
@@ -11,4 +11,4 @@
 # expect_snapshot_plot(f, label = "ylab_good")
 # 
 # # reset par
-# par(op)
+# par(op) 


### PR DESCRIPTION
Close #47. I didn't try on many plots myself but it looks like it passes the CI. Sorry for all for the git changes, I don't know why it's like this, the changes are just a few lines at the beginning of `plot2.default()`.

@grantmcdermott I'm still struggling with the tests suite of this package (esp. because I'm currently on Windows) so it's probably better if you can take over this PR to generate snapshots. 

New behavior:

``` r
set.seed(42)
plot(rnorm(1))
```

![](https://i.imgur.com/T6mQdGC.png)<!-- -->

``` r

library(plot2)
set.seed(42)
plot2(rnorm(1))
```

![](https://i.imgur.com/YLpYIvK.png)<!-- -->
