### PR TITLE
Automatic ribbon order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3.9002
+Version: 0.0.3.9003
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# plot2 0.0.3.9002 (development version)
+# plot2 0.0.3.9003 (development version)
 
 New features:
 
@@ -11,6 +11,10 @@ Bug fixes:
 
 - Y-label correctly prints if a function was used for the atomic plot method,
 e.g. `plot2(rnorm(100)`. (#52 etiennebacher)
+- Ribbon plot types are now automatically ordered by the x variable (#54
+@grantmcdermott).
+- Interval plots like ribbons, errorbars, and pointranges are now correctly
+plotted even if a y variable isn't specified (#54 @grantmcdermott).
 
 # plot2 0.0.3
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -290,9 +290,18 @@ plot2.default = function(
   }
   
   if (is.null(y)) {
-    y = x
-    x = seq_along(x)
-    xlab = "Index"
+    ## Special catch for interval plots without a specified y-var
+    if (type %in% c("pointrange", "errorbar", "ribbon")) {
+      ymin_dep = deparse(substitute(ymin)) 
+      ymax_dep = deparse(substitute(ymax))
+      y_dep = paste0("[", ymin_dep, ", ", ymax_dep, "]")
+      y = rep(NA, length(x))
+      if (is.null(ylim)) ylim = range(c(ymin, ymax))
+    } else {
+      y = x
+      x = seq_along(x)
+      xlab = "Index"
+    }
   }
   
   if (is.null(xlab)) xlab = x_dep

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -310,6 +310,14 @@ plot2.default = function(
       names(xlabs) = xlvls
       x = as.integer(x)
     }
+    if (type == "ribbon") {
+      xord = order(x) 
+      x = x[xord]
+      y = y[xord]
+      ymin = ymin[xord]
+      ymax = ymax[xord]
+      rm(xord)
+    }
   }
   
   if (is.null(xlim)) xlim = range(x, na.rm = TRUE)

--- a/inst/tinytest/_tinysnapshot/ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ribbon.svg
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='122.22' y1='430.56' x2='416.77' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='122.22' y1='430.56' x2='122.22' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='220.40' y1='430.56' x2='220.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='318.59' y1='430.56' x2='318.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='416.77' y1='430.56' x2='416.77' y2='437.76' style='stroke-width: 0.75;' />
+<text x='122.22' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='220.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='318.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='416.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='424.08' x2='59.04' y2='91.86' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='424.08' x2='51.84' y2='424.08' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='357.63' x2='51.84' y2='357.63' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='291.19' x2='51.84' y2='291.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='224.74' x2='51.84' y2='224.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.30' x2='51.84' y2='158.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='91.86' x2='51.84' y2='91.86' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,424.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,357.63) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,291.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,224.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,158.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,91.86) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<polygon points='74.40,132.21 84.41,138.11 106.02,150.93 115.83,156.81 135.96,168.96 141.85,172.55 153.63,179.79 167.87,188.66 183.09,198.32 197.82,207.89 198.80,208.53 208.13,214.74 235.13,233.41 237.09,234.81 239.06,236.22 241.51,237.99 263.11,253.99 263.60,254.36 263.60,254.36 263.60,254.36 265.57,255.85 271.46,260.36 276.37,264.16 276.37,264.16 292.08,276.51 296.98,280.43 302.88,285.17 303.37,285.57 325.46,303.62 441.32,402.04 450.64,410.09 458.40,416.80 458.40,343.73 450.64,339.22 441.32,333.78 325.46,264.59 303.37,250.68 302.88,250.37 296.98,246.58 292.08,243.40 276.37,233.03 276.37,233.03 271.46,229.72 265.57,225.71 263.60,224.36 263.60,224.36 263.60,224.36 263.11,224.02 241.51,208.77 239.06,206.99 237.09,205.55 235.13,204.12 208.13,183.73 198.80,176.44 197.82,175.66 183.09,163.93 167.87,151.57 153.63,139.84 141.85,130.04 135.96,125.11 115.83,108.14 106.02,99.81 84.41,81.38 74.40,72.80 ' style='stroke-width: 0.75; stroke: none; fill: #000000; fill-opacity: 0.20;' />
+<polyline points='74.40,102.50 84.41,109.75 106.02,125.37 115.83,132.47 135.96,147.03 141.85,151.29 153.63,159.82 167.87,170.11 183.09,181.12 197.82,191.78 198.80,192.49 208.13,199.23 235.13,218.76 237.09,220.18 239.06,221.61 241.51,223.38 263.11,239.01 263.60,239.36 263.60,239.36 263.60,239.36 265.57,240.78 271.46,245.04 276.37,248.59 276.37,248.59 292.08,259.96 296.98,263.51 302.88,267.77 303.37,268.12 325.46,284.10 441.32,367.91 450.64,374.66 458.40,380.27 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='9.33px' lengthAdjust='spacingAndGlyphs'>fit</text>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/ribbon_no_y.svg
+++ b/inst/tinytest/_tinysnapshot/ribbon_no_y.svg
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='122.22' y1='430.56' x2='416.77' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='122.22' y1='430.56' x2='122.22' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='220.40' y1='430.56' x2='220.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='318.59' y1='430.56' x2='318.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='416.77' y1='430.56' x2='416.77' y2='437.76' style='stroke-width: 0.75;' />
+<text x='122.22' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='220.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='318.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='416.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='424.08' x2='59.04' y2='91.86' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='424.08' x2='51.84' y2='424.08' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='357.63' x2='51.84' y2='357.63' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='291.19' x2='51.84' y2='291.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='224.74' x2='51.84' y2='224.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.30' x2='51.84' y2='158.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='91.86' x2='51.84' y2='91.86' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,424.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,357.63) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,291.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,224.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,158.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,91.86) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<polygon points='74.40,132.21 84.41,138.11 106.02,150.93 115.83,156.81 135.96,168.96 141.85,172.55 153.63,179.79 167.87,188.66 183.09,198.32 197.82,207.89 198.80,208.53 208.13,214.74 235.13,233.41 237.09,234.81 239.06,236.22 241.51,237.99 263.11,253.99 263.60,254.36 263.60,254.36 263.60,254.36 265.57,255.85 271.46,260.36 276.37,264.16 276.37,264.16 292.08,276.51 296.98,280.43 302.88,285.17 303.37,285.57 325.46,303.62 441.32,402.04 450.64,410.09 458.40,416.80 458.40,343.73 450.64,339.22 441.32,333.78 325.46,264.59 303.37,250.68 302.88,250.37 296.98,246.58 292.08,243.40 276.37,233.03 276.37,233.03 271.46,229.72 265.57,225.71 263.60,224.36 263.60,224.36 263.60,224.36 263.11,224.02 241.51,208.77 239.06,206.99 237.09,205.55 235.13,204.12 208.13,183.73 198.80,176.44 197.82,175.66 183.09,163.93 167.87,151.57 153.63,139.84 141.85,130.04 135.96,125.11 115.83,108.14 106.02,99.81 84.41,81.38 74.40,72.80 ' style='stroke-width: 0.75; stroke: none; fill: #000000; fill-opacity: 0.20;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>[lwr, upr]</text>
+</g>
+</svg>

--- a/inst/tinytest/test-ribbon.R
+++ b/inst/tinytest/test-ribbon.R
@@ -1,0 +1,32 @@
+source("helpers.R")
+using("tinysnapshot")
+
+mod = lm(mpg ~ wt, mtcars)
+pred = predict(mod, interval = "confidence")
+
+mtcars2 = cbind(mtcars, pred)
+
+
+f = function() {
+  with(
+    mtcars2,
+    plot2(
+      x = wt, y = fit,
+      ymin = lwr, ymax = upr,
+      type = "ribbon"
+    )
+  )
+}
+expect_snapshot_plot(f, label = "ribbon")
+
+f = function() {
+  with(
+    mtcars2,
+    plot2(
+      x = wt,
+      ymin = lwr, ymax = upr,
+      type = "ribbon"
+    )
+  )
+}
+expect_snapshot_plot(f, label = "ribbon_no_y")


### PR DESCRIPTION
Fixes #53 .

``` r
devtools::load_all("~/Documents/Projects/plot2")
#> ℹ Loading plot2

mod = lm(mpg ~ wt, mtcars)
pred = predict(mod, interval = "confidence")

mtcars2 = cbind(mtcars, pred)

with(
  mtcars2,
  plot2(
    x = wt, y = fit,
    ymin = lwr, ymax = upr,
    type = "ribbon"
  )
)
```

![](https://i.imgur.com/fbvs1f7.png)<!-- -->

This PR also allows interval plot types (ribbon, pointrange, etc) to be specified without a yvar.

``` r

with(
  mtcars2,
  plot2(
    x = wt, 
    ymin = lwr, ymax = upr,
    type = "ribbon"
  )
)
```

![](https://i.imgur.com/6hdBJzs.png)<!-- -->
