### PR TITLE
Support add=TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3.9004
+Version: 0.0.3.9005
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# plot2 0.0.3.9004 (development version)
+# plot2 0.0.3.9005 (development version)
 
 New features:
 
@@ -6,8 +6,9 @@ New features:
 convenience keyword similar to `lty` and `pch`. This is useful for plotting
 filled point characters (e.g., pch = 21), where you want a different colour for
 the fill and border. (#50 @grantmcdermott)
-
 - Support for filled density plots. (#58 @grantmcdermott)
+- The new `add` argument allows new plot2 objects to be added to / on top of the
+existing plot window. (#60 @grantmcdermott)
 
 Bug fixes:
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -135,6 +135,9 @@
 #' @param ribbon_alpha numeric factor modifying the opacity alpha of any ribbon
 #'   shading; typically in `[0, 1]`. Default value is 0.2. Only used when
 #'   `type = "ribbon"`.
+#' @param logical. If TRUE, then elements are added to the current plot rather
+#'   than drawing a new plot window. Note that the automatic legend for the
+#'   added elements will be turned off.
 #' @param ... 	other `graphical` parameters (see `par` and also the "Details"
 #'   section of `plot`).
 #'   
@@ -285,9 +288,12 @@ plot2.default = function(
     ymin = NULL,
     ymax = NULL,
     ribbon_alpha = 0.2,
+    add = FALSE,
     ...) {
   
   dots = list(...)
+  
+  if (isTRUE(add)) legend = FALSE
   
   # Capture deparsed expressions early, before x, y and by are evaluated
   x_dep = deparse(substitute(x))
@@ -581,7 +587,7 @@ plot2.default = function(
     
     do.call("legend", legend.args)
     
-  } else if(legend.args[["x"]]=="none") {
+  } else if(legend.args[["x"]]=="none" && isFALSE(add)) {
     
     plot.new()
     
@@ -597,28 +603,51 @@ plot2.default = function(
   # )
   ## Solution: Only pass on relevant args using name checking and do.call.
   ## Idea borrowed from here: https://stackoverflow.com/a/4128401/4115816
-  pdots = dots[names(dots) %in% names(formals(graphics::plot.default))]
-  do.call(
-    "plot.window",
-    c(list(xlim = xlim, ylim = ylim, asp = asp, log = log), pdots)
-  )
-  
-  # axes, plot.frame and grid
-  if (axes) {
-    if (type %in% c("pointrange", "errorbar", "ribbon") && !is.null(xlabs)) {
-      axis(1, at = xlabs, labels = names(xlabs))
-    } else {
-      axis(1)
+  if (isFALSE(add)) {
+    pdots = dots[names(dots) %in% names(formals(graphics::plot.default))]
+    do.call(
+      "plot.window",
+      c(list(xlim = xlim, ylim = ylim, asp = asp, log = log), pdots)
+    )
+    
+    # axes, plot.frame and grid
+    if (isTRUE(axes)) {
+      if (type %in% c("pointrange", "errorbar", "ribbon") && !is.null(xlabs)) {
+        axis(1, at = xlabs, labels = names(xlabs))
+      } else {
+        axis(1)
+      }
+      axis(2)
     }
-    axis(2)
-  }
-  if (frame.plot) box()
-  if (!is.null(grid)) {
-    if (is.logical(grid)) {
-      if (isTRUE(grid)) grid()
-    } else {
-      grid
+    if (frame.plot) box()
+    if (!is.null(grid)) {
+      if (is.logical(grid)) {
+        if (isTRUE(grid)) grid()
+      } else {
+        grid
+      }
     }
+    
+    
+    # Titles. Note that we include a special catch for the main title if legend is
+    # "top!" (and main is specified in the first place).
+    if (is.null(main) || is.null(outer_bottom) || isTRUE(outer_bottom)) {
+      title(
+        xlab = xlab,
+        ylab = ylab,
+        main = main,
+        sub = sub
+      )
+    } else {
+      title(
+        xlab = xlab,
+        ylab = ylab,
+        sub = sub
+      )
+      # Bump main up to make space for the legend beneath it
+      title(main = main, line = 5, xpd = NA)
+    }
+      
   }
 
   # polygons before lines
@@ -718,24 +747,6 @@ plot2.default = function(
     stop("`type` argument not supported.", call. = FALSE)
   }
 
-  # Titles. Note that we include a special catch for the main title if legend is
-  # "top!" (and main is specified in the first place).
-  if (is.null(main) || is.null(outer_bottom) || isTRUE(outer_bottom)) {
-    title(
-      xlab = xlab,
-      ylab = ylab,
-      main = main,
-      sub = sub
-    )
-  } else {
-    title(
-      xlab = xlab,
-      ylab = ylab,
-      sub = sub
-    )
-    # Bump main up to make space for the legend beneath it
-    title(main = main, line = 5, xpd = NA)
-  }
   
   
   if (par_restore) {

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -135,10 +135,10 @@
 #' @param ribbon_alpha numeric factor modifying the opacity alpha of any ribbon
 #'   shading; typically in `[0, 1]`. Default value is 0.2. Only used when
 #'   `type = "ribbon"`.
-#' @param logical. If TRUE, then elements are added to the current plot rather
+#' @param add logical. If TRUE, then elements are added to the current plot rather
 #'   than drawing a new plot window. Note that the automatic legend for the
 #'   added elements will be turned off.
-#' @param ... 	other `graphical` parameters (see `par` and also the "Details"
+#' @param ... other `graphical` parameters (see `par` and also the "Details"
 #'   section of `plot`).
 #'   
 #' @importFrom grDevices adjustcolor palette palette.colors palette.pals hcl.colors hcl.pals

--- a/inst/tinytest/_tinysnapshot/addTRUE.svg
+++ b/inst/tinytest/_tinysnapshot/addTRUE.svg
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='444.02' y1='235.80' x2='457.83' y2='235.80' style='stroke-width: 0.75;' />
+<line x1='444.02' y1='253.80' x2='457.83' y2='253.80' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='444.02' y1='271.80' x2='457.83' y2='271.80' style='stroke-width: 0.75; stroke: #61D04F;' />
+<rect x='442.55' y='227.43' width='16.75' height='16.75' style='stroke-width: 0.00; fill: #000000; fill-opacity: 0.20;' />
+<rect x='442.55' y='245.43' width='16.75' height='16.75' style='stroke-width: 0.00; stroke: #DF536B; fill: #DF536B; fill-opacity: 0.20;' />
+<rect x='442.55' y='263.43' width='16.75' height='16.75' style='stroke-width: 0.00; stroke: #61D04F; fill: #61D04F; fill-opacity: 0.20;' />
+<text x='460.89' y='216.00' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='468.88' y='239.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='468.88' y='257.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='468.88' y='275.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<line x1='115.70' y1='430.56' x2='379.88' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='115.70' y1='430.56' x2='115.70' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='203.76' y1='430.56' x2='203.76' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='291.82' y1='430.56' x2='291.82' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='379.88' y1='430.56' x2='379.88' y2='437.76' style='stroke-width: 0.75;' />
+<text x='115.70' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='203.76' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='291.82' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='379.88' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='386.02' x2='59.04' y2='89.41' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='386.02' x2='51.84' y2='386.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='311.87' x2='51.84' y2='311.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='237.72' x2='51.84' y2='237.72' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='163.56' x2='51.84' y2='163.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='89.41' x2='51.84' y2='89.41' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,386.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,311.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,237.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,163.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,89.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 430.99,430.56 430.99,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MzIuNDN8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='432.43' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MzIuNDN8MC4wMHw1MDQuMDA=)'>
+<text x='245.01' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='9.33px' lengthAdjust='spacingAndGlyphs'>fit</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDMwLjk5fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='371.95' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDMwLjk5fDU5LjA0fDQzMC41Ng==)'>
+<polygon points='72.82,131.51 81.80,135.01 101.17,143.06 109.98,146.98 128.03,155.62 133.31,158.32 143.88,163.95 156.65,171.19 184.39,188.40 216.97,210.65 220.49,213.15 220.49,150.62 216.97,149.32 184.39,136.38 156.65,123.64 143.88,117.09 133.31,111.31 128.03,108.31 109.98,97.46 101.17,91.87 81.80,79.00 72.82,72.80 ' style='stroke-width: 0.75; stroke: none; fill: #000000; fill-opacity: 0.20;' />
+<polygon points='170.30,249.39 183.51,255.44 192.75,259.90 222.69,275.63 242.50,287.16 242.50,287.16 244.27,288.22 244.27,227.44 242.50,226.60 242.50,226.60 222.69,216.74 192.75,200.14 183.51,194.61 170.30,186.41 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B; fill-opacity: 0.20;' />
+<polygon points='218.73,299.10 242.06,308.02 242.50,308.20 249.55,311.09 253.95,312.95 253.95,312.95 268.04,319.25 272.44,321.32 277.73,323.90 278.17,324.11 297.98,334.58 401.89,405.23 410.26,411.53 417.21,416.80 417.21,339.45 410.26,337.21 401.89,334.47 297.98,292.93 278.17,282.00 277.73,281.74 272.44,278.61 268.04,275.93 253.95,267.01 253.95,267.01 249.55,264.12 242.50,259.41 242.06,259.11 218.73,242.83 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F; fill-opacity: 0.20;' />
+<polyline points='72.82,102.16 81.80,107.00 101.17,117.46 109.98,122.22 128.03,131.96 133.31,134.82 143.88,140.52 156.65,147.41 184.39,162.39 216.97,179.98 220.49,181.88 ' style='stroke-width: 0.75;' />
+<polyline points='170.30,217.90 183.51,225.03 192.75,230.02 222.69,246.18 242.50,256.88 242.50,256.88 244.27,257.83 ' style='stroke-width: 0.75; stroke: #DF536B;' />
+<polyline points='218.73,270.97 242.06,283.56 242.50,283.80 249.55,287.61 253.95,289.98 253.95,289.98 268.04,297.59 272.44,299.97 277.73,302.82 278.17,303.06 297.98,313.75 401.89,369.85 410.26,374.37 417.21,378.12 ' style='stroke-width: 0.75; stroke: #61D04F;' />
+<circle cx='143.88' cy='196.19' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='220.49' cy='172.46' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='216.97' cy='196.19' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='133.31' cy='53.82' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='81.80' cy='83.48' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='101.17' cy='31.57' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='156.65' cy='215.47' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='109.98' cy='129.45' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='128.03' cy='148.73' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='72.82' cy='83.48' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='184.39' cy='216.95' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='170.30' cy='222.89' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='192.75' cy='222.89' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='222.69' cy='216.95' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='244.27' cy='265.90' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='242.50' cy='249.58' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='242.50' cy='270.35' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='183.51' cy='242.17' r='2.70' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<circle cx='242.50' cy='257.00' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='253.95' cy='322.25' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='297.98' cy='291.11' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='268.04' cy='277.76' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='272.44' cy='308.91' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='401.89' cy='380.09' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='417.21' cy='380.09' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='410.26' cy='316.32' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='249.55' cy='304.46' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='242.06' cy='308.91' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='277.73' cy='337.08' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='278.17' cy='249.58' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='218.73' cy='300.01' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<circle cx='253.95' cy='311.87' r='2.70' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+</g>
+</svg>

--- a/inst/tinytest/test-misc.R
+++ b/inst/tinytest/test-misc.R
@@ -28,3 +28,18 @@ f = function() {
   plot2(Temp ~ Day, data = airquality, log = "yx")
 } 
 expect_snapshot_plot(f, label = "arg_log_yx")
+
+f = function() {
+  par(mfrow = c(1, 1))
+  pred = predict(lm(mpg~wt+factor(cyl),mtcars), interval = "confidence")
+  m = cbind(mtcars, pred)
+  with(
+    m,
+    plot2(wt, fit, ymin = lwr, ymax = upr, by = cyl, type = "ribbon")
+  )
+  with(
+    m,
+    plot2(wt, mpg, by = cyl, pch = 19, add = TRUE)
+  )
+}
+expect_snapshot_plot(f, label = "addTRUE")

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -247,16 +247,16 @@ used when the \code{type} argument is one of "pointrange", "errorbar", or
 shading; typically in \verb{[0, 1]}. Default value is 0.2. Only used when
 \code{type = "ribbon"}.}
 
+\item{add}{logical. If TRUE, then elements are added to the current plot rather
+than drawing a new plot window. Note that the automatic legend for the
+added elements will be turned off.}
+
 \item{formula}{a \code{formula} that may also include a grouping variable after a
 "|", such as \code{y ~ x | z}. Note that the \code{formula} and \code{x} arguments should
 not be specified in the same call.}
 
 \item{subset, na.action, drop.unused.levels}{arguments passed to \code{model.frame}
 when extracting the data from \code{formula} and \code{data}.}
-
-\item{logical.}{If TRUE, then elements are added to the current plot rather
-than drawing a new plot window. Note that the automatic legend for the
-added elements will be turned off.}
 }
 \description{
 Extends base R's

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -38,6 +38,7 @@ plot2(x, ...)
   ymin = NULL,
   ymax = NULL,
   ribbon_alpha = 0.2,
+  add = FALSE,
   ...
 )
 
@@ -252,6 +253,10 @@ not be specified in the same call.}
 
 \item{subset, na.action, drop.unused.levels}{arguments passed to \code{model.frame}
 when extracting the data from \code{formula} and \code{data}.}
+
+\item{logical.}{If TRUE, then elements are added to the current plot rather
+than drawing a new plot window. Note that the automatic legend for the
+added elements will be turned off.}
 }
 \description{
 Extends base R's


### PR DESCRIPTION
Closes #55. Simplifies things by ignoring the legend for any added elements. (Maybe we can revisit down the line.)

Simple penguins example.

``` r
library(plot2)
par(pch = 15)

data(penguins, package = "palmerpenguins")

plot2(bill_depth_mm ~ bill_length_mm | species, penguins, pch = "by", grid = TRUE)

penguins$pred = predict(lm(bill_depth_mm ~ bill_length_mm * species, penguins), newdata = penguins)

plot2(pred ~ bill_length_mm | species, penguins, type = "l", add = TRUE)
```

![](https://i.imgur.com/ucgAxjZ.png)<!-- -->

<sup>Created on 2023-08-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>