### PR TITLE
Support type = "density"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3.9005
+Version: 0.0.3.9006
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3.9006
+Version: 0.0.3.9007
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# plot2 0.0.3.9006 (development version)
+# plot2 0.0.3.9007 (development version)
 
 New features:
 
@@ -11,6 +11,9 @@ the fill and border. (#50 @grantmcdermott)
 existing plot window. (#60 @grantmcdermott)
 - Support for one-sided formulas, e.g. `plot2(~ Temp | Month, airquality)`. (#62
 @grantmcdermott and @zeileis)
+- Support for `plot2(x, type = "density")` as an alternative to
+`plot2(density(x))`. Works for both the atomic and one-sided formula methods.
+(#66 @grantmcdermott)
 
 Bug fixes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# plot2 0.0.3.9005 (development version)
+# plot2 0.0.3.9006 (development version)
 
 New features:
 
@@ -9,6 +9,8 @@ the fill and border. (#50 @grantmcdermott)
 - Support for filled density plots. (#58 @grantmcdermott)
 - The new `add` argument allows new plot2 objects to be added to / on top of the
 existing plot window. (#60 @grantmcdermott)
+- Support for one-sided formulas, e.g. `plot2(~ Temp | Month, airquality)`. (#62
+@grantmcdermott and @zeileis)
 
 Bug fixes:
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -7,7 +7,7 @@
 #'   these categories (groups) using modern colour palettes. Coincident with
 #'   this grouping support, `plot2` also produces automatic legends with scope
 #'   for further customization. While the package also offers several other
-#'   minor enhancements, it tries as far as possible to be a drop-in replacement
+#'   enhancements, it tries as far as possible to be a drop-in replacement
 #'   for the equivalent base plot function. Users should generally be able to
 #'   swap a valid `plot` call with `plot2` without any changes to the output.
 #' 
@@ -16,11 +16,12 @@
 #'   plot. Any reasonable way of defining the coordinates is acceptable. See
 #'   the function xy.coords for details. If supplied separately, they must be
 #'   of the same length.
-#' @param by the grouping variable that you want to categorize (i.e., colour)
+#' @param by the grouping variable(s) that you want to categorize (i.e., colour)
 #'   the plot by.
-#' @param formula a `formula` that may also include a grouping variable after a
-#'   "|", such as `y ~ x | z`. Note that the `formula` and `x` arguments should
-#'   not be specified in the same call.
+#' @param formula a `formula` that optionally includes grouping variable(s)
+#'   after a vertical bar, e.g. `y ~ x | z`. One-sided formulae are also
+#'   permitted, e.g. `~ y | z`. Note that the `formula` and `x` arguments
+#'   should not be specified in the same call.
 #' @param data a data.frame (or list) from which the variables in formula
 #'   should be taken. A matrix is converted to a data frame.
 #' @param type character string giving the type of plot desired. Options are:
@@ -29,10 +30,8 @@
 #'   lines, "o" for overplotted points and lines, "s" and "S" for stair steps
 #'   and "h" for histogram-like vertical lines. "n" does not produce
 #'   any points or lines.
-#'   - Additional plot2 types: "pointrange", "errorbar", and "ribbon" for
-#'   drawing these interval plot types. (Note that specifying "ribbon" for
-#'   objects of class `density` will yield a density plot with a shaded
-#'   interior.)
+#'   - Additional plot2 types: "density" for drawing density plots, and
+#'   "pointrange", "errorbar" or "ribbon" for drawing interval plots.
 #' @param xlim the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
 #'   and leads to a ‘reversed axis’. The default value, NULL, indicates that
 #'   the range of the `finite` values to be plotted should be used.
@@ -112,10 +111,16 @@
 #'   line type will automatically loop over the number groups. This automatic
 #'   looping will begin at the global line type value (i.e., `par("lty")`) and
 #'   recycle as necessary.
-#' @param bg background (fill) color for the open plot symbols 21:25: see
-#'   `points.default`. In addition, users can supply a special `bg = "by"`
-#'   convenience argument, in which case the background color will inherit the
-#'   automatic group coloring intended for the `col` parameter.
+#' @param bg background fill color for the open plot symbols 21:25 (see
+#'   `points.default`), as well as ribbon plots types. For the latter
+#'   group---including filled density plots---an automatic alpha transparency
+#'   adjustment will be applied (see the `ribbon_alpha` argument further below).
+#'   Users can also supply a special `bg = "by"` convenience argument, in which
+#'   case the background fill will inherit the automatic group coloring
+#'   intended for the `col` argument. Note that this grouped inheritance will
+#'   persist even if the `col` defaults are themselves overridden. For example,
+#'   `plot2(y ~ x | z, data = fakedata, pch = 22, col = "blue", bg = "by")`
+#'   will yield filled squares with a blue border.
 #' @param cex character expansion. A numerical vector (can be a single value)
 #'   giving the amount by which plotting characters and symbols should be scaled
 #'   relative to the default. Note that NULL is equivalent to 1.0, while NA
@@ -134,7 +139,8 @@
 #'   "ribbon".
 #' @param ribbon_alpha numeric factor modifying the opacity alpha of any ribbon
 #'   shading; typically in `[0, 1]`. Default value is 0.2. Only used when
-#'   `type = "ribbon"`.
+#'   `type = "ribbon"`, or when the `bg` fill argument is specified in a density
+#'   plot (since filled density plots are converted to ribbon plots internally).
 #' @param add logical. If TRUE, then elements are added to the current plot rather
 #'   than drawing a new plot window. Note that the automatic legend for the
 #'   added elements will be turned off.

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -315,13 +315,9 @@ plot2.default = function(
     fargs = mget(ls(environment(), sorted = FALSE))
     fargs = modifyList(fargs, dots)
     fargs$type = "l"
-    if (is.null(main) && is.null(y)) {
-      if (!is.null(ylab)) {
-        fargs$main = paste0("density.default(x = ", ylab, ")")
-      } else {
-        fargs$main = paste0("density.default(x = ", y_dep, ")")
-      }
-    }
+    # explicitly turn off `default.density(x = ...)` title for
+    # type = "density" plots (to make consistent with regular plot)
+    if (is.null(fargs$main)) fargs$main = NA
     ## Catch for atomic density type to avoid "by" as legend title
     if (is.null(fargs[["legend.args"]][["title"]])) {
       fargs[["legend.args"]][["title"]] = by_dep

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -988,7 +988,7 @@ plot2.density = function(
       xlab = paste0("N = ", n, "   Joint Bandwidth = ", bw)
     }
   }
-  if (type=="ribbon") {
+  if (type == "ribbon") {
     ymin = rep(0, length(y))
     ymax = y
     # set extra legend params to get bordered boxes with fill

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -314,6 +314,10 @@ plot2.default = function(
   if (type == "density") {
     fargs = mget(ls(environment(), sorted = FALSE))
     fargs = modifyList(fargs, dots)
+    if (!is.null(fargs[["y"]])) {
+      fargs[["y"]] = NULL
+      message("\nNote: A `y` argument has been supplied, but will be ignored for density plots.\n")
+    }
     fargs$type = "l"
     # explicitly turn off `default.density(x = ...)` title for
     # type = "density" plots (to make consistent with regular plot)

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -100,7 +100,7 @@ of the same length.}
 \item{...}{other \code{graphical} parameters (see \code{par} and also the "Details"
 section of \code{plot}).}
 
-\item{by}{the grouping variable that you want to categorize (i.e., colour)
+\item{by}{the grouping variable(s) that you want to categorize (i.e., colour)
 the plot by.}
 
 \item{data}{a data.frame (or list) from which the variables in formula
@@ -113,10 +113,8 @@ for lines, "b" for both points and lines, "c" for empty points joined by
 lines, "o" for overplotted points and lines, "s" and "S" for stair steps
 and "h" for histogram-like vertical lines. "n" does not produce
 any points or lines.
-\item Additional plot2 types: "pointrange", "errorbar", and "ribbon" for
-drawing these interval plot types. (Note that specifying "ribbon" for
-objects of class \code{density} will yield a density plot with a shaded
-interior.)
+\item Additional plot2 types: "density" for drawing density plots, and
+"pointrange", "errorbar" or "ribbon" for drawing interval plots.
 }}
 
 \item{xlim}{the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
@@ -221,10 +219,16 @@ this grouping process. Typically, this would only be done if grouping
 features are deferred to some other graphical parameter (i.e., passing the
 "by" keyword to one of \code{pch}, \code{lty}, or \code{bg}; see below.)}
 
-\item{bg}{background (fill) color for the open plot symbols 21:25: see
-\code{points.default}. In addition, users can supply a special \code{bg = "by"}
-convenience argument, in which case the background color will inherit the
-automatic group coloring intended for the \code{col} parameter.}
+\item{bg}{background fill color for the open plot symbols 21:25 (see
+\code{points.default}), as well as ribbon plots types. For the latter
+group---including filled density plots---an automatic alpha transparency
+adjustment will be applied (see the \code{ribbon_alpha} argument further below).
+Users can also supply a special \code{bg = "by"} convenience argument, in which
+case the background fill will inherit the automatic group coloring
+intended for the \code{col} argument. Note that this grouped inheritance will
+persist even if the \code{col} defaults are themselves overridden. For example,
+\code{plot2(y ~ x | z, data = fakedata, pch = 22, col = "blue", bg = "by")}
+will yield filled squares with a blue border.}
 
 \item{cex}{character expansion. A numerical vector (can be a single value)
 giving the amount by which plotting characters and symbols should be scaled
@@ -245,15 +249,17 @@ used when the \code{type} argument is one of "pointrange", "errorbar", or
 
 \item{ribbon_alpha}{numeric factor modifying the opacity alpha of any ribbon
 shading; typically in \verb{[0, 1]}. Default value is 0.2. Only used when
-\code{type = "ribbon"}.}
+\code{type = "ribbon"}, or when the \code{bg} fill argument is specified in a density
+plot (since filled density plots are converted to ribbon plots internally).}
 
 \item{add}{logical. If TRUE, then elements are added to the current plot rather
 than drawing a new plot window. Note that the automatic legend for the
 added elements will be turned off.}
 
-\item{formula}{a \code{formula} that may also include a grouping variable after a
-"|", such as \code{y ~ x | z}. Note that the \code{formula} and \code{x} arguments should
-not be specified in the same call.}
+\item{formula}{a \code{formula} that optionally includes grouping variable(s)
+after a vertical bar, e.g. \code{y ~ x | z}. One-sided formulae are also
+permitted, e.g. \code{~ y | z}. Note that the \code{formula} and \code{x} arguments
+should not be specified in the same call.}
 
 \item{subset, na.action, drop.unused.levels}{arguments passed to \code{model.frame}
 when extracting the data from \code{formula} and \code{data}.}
@@ -266,7 +272,7 @@ different categories of a dataset in a single function call and highlight
 these categories (groups) using modern colour palettes. Coincident with
 this grouping support, \code{plot2} also produces automatic legends with scope
 for further customization. While the package also offers several other
-minor enhancements, it tries as far as possible to be a drop-in replacement
+enhancements, it tries as far as possible to be a drop-in replacement
 for the equivalent base plot function. Users should generally be able to
 swap a valid \code{plot} call with \code{plot2} without any changes to the output.
 }


### PR DESCRIPTION
Closes #61.

Supports `type = "density"` for both the atomic...

``` r
devtools::load_all("~/Documents/Projects/plot2")
#> ℹ Loading plot2

with(airquality, plot2(Temp, type = "density"))
```

![](https://i.imgur.com/ATxlJJ6.png)<!-- -->

``` r
with(airquality, plot2(Temp, type = "density", by = Month, bg = "by"))
```

![](https://i.imgur.com/cnyscl9.png)<!-- -->

... and one-sided formula methods:

``` r
plot2(~Temp, airquality, type = "density")
```

![](https://i.imgur.com/TXJAokH.png)<!-- -->

``` r
plot2(~Temp | Month, airquality, type = "density", bg = "by")
```

![](https://i.imgur.com/uhhNCU2.png)<!-- -->

