### PR TITLE
Support area plot types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plot2
 Type: Package
 Title: Lightweight extension of base R plot
-Version: 0.0.3.9007
+Version: 0.0.3.9008
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# plot2 0.0.3.9007 (development version)
+# plot2 0.0.3.9008 (development version)
 
 New features:
 
@@ -14,6 +14,8 @@ existing plot window. (#60 @grantmcdermott)
 - Support for `plot2(x, type = "density")` as an alternative to
 `plot2(density(x))`. Works for both the atomic and one-sided formula methods.
 (#66 @grantmcdermott)
+- Support for "area" type plots as a special case of ribbon plots (#68
+@grantmcdermott)
 
 Bug fixes:
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -30,8 +30,10 @@
 #'   lines, "o" for overplotted points and lines, "s" and "S" for stair steps
 #'   and "h" for histogram-like vertical lines. "n" does not produce
 #'   any points or lines.
-#'   - Additional plot2 types: "density" for drawing density plots, and
-#'   "pointrange", "errorbar" or "ribbon" for drawing interval plots.
+#'   - Additional plot2 types: "density" for densities, "pointrange" or
+#'   "errorbar" for segement intervals, and "ribbon" or "area" for polygon
+#'   intervals (where area plots are a special case of ribbon plots with `ymin`
+#'   set to 0 and `ymax` set to `y`; see below).
 #' @param xlim the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
 #'   and leads to a ‘reversed axis’. The default value, NULL, indicates that
 #'   the range of the `finite` values to be plotted should be used.
@@ -112,7 +114,7 @@
 #'   looping will begin at the global line type value (i.e., `par("lty")`) and
 #'   recycle as necessary.
 #' @param bg background fill color for the open plot symbols 21:25 (see
-#'   `points.default`), as well as ribbon plot types. For the latter
+#'   `points.default`), as well as ribbon and area plot types. For the latter
 #'   group---including filled density plots---an automatic alpha transparency
 #'   adjustment will be applied (see the `ribbon_alpha` argument further below).
 #'   Users can also supply a special `bg = "by"` convenience argument, in which
@@ -326,10 +328,10 @@ plot2.default = function(
     if (is.null(fargs[["legend.args"]][["title"]])) {
       fargs[["legend.args"]][["title"]] = by_dep
     }
-    fargs$y = fargs$ymin = fargs$ymax = fargs$ylab  = fargs$xlab = NULL
+    fargs$y = fargs$ymin = fargs$ymax = fargs$ylab = fargs$xlab = NULL
     return(do.call(plot2.density, args = fargs))
   }
-
+  
   if (is.null(y)) {
     ## Special catch for interval plots without a specified y-var
     if (type %in% c("pointrange", "errorbar", "ribbon")) {
@@ -374,7 +376,13 @@ plot2.default = function(
       rm(xord)
     }
   }
-  
+
+  if (type == "area") {
+    ymax = y
+    ymin = rep.int(0, length(y))
+    type = "ribbon"
+  }
+
   if (is.null(xlim)) xlim = range(x, na.rm = TRUE)
   if (is.null(ylim)) ylim = range(y, na.rm = TRUE)
 
@@ -914,7 +922,7 @@ plot2.formula = function(
 plot2.density = function(
     x = NULL,
     by = NULL,
-    type = c("l", "ribbon"),
+    type = c("l", "area"),
     xlim = NULL,
     ylim = NULL,
     # log = "",
@@ -937,7 +945,7 @@ plot2.density = function(
 
   type = match.arg(type)
   ## override if bg = "by"
-  if (!is.null(bg)) type = "ribbon"
+  if (!is.null(bg)) type = "area"
 
   if (inherits(x, "density")) {
     object = x
@@ -992,17 +1000,16 @@ plot2.density = function(
       xlab = paste0("N = ", n, "   Joint Bandwidth = ", bw)
     }
   }
-  if (type == "ribbon") {
+  # if (type == "ribbon") {
+  if (type == "area") {
     ymin = rep(0, length(y))
     ymax = y
     # set extra legend params to get bordered boxes with fill
     legend.args[["x.intersp"]] = 1.25
     legend.args[["lty"]] = 0
     legend.args[["pt.lwd"]] = 1
-  } else {
-    ymin = ymax = NULL
   }
-  
+
   ## axes range
   if (is.null(xlim)) xlim = range(x)
   if (is.null(ylim)) ylim = range(y)
@@ -1033,8 +1040,6 @@ plot2.density = function(
     bg = bg,
     lty = lty,
     par_restore = par_restore,
-    ymin = ymin,
-    ymax = ymax,
     ...
     )
 

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -350,6 +350,12 @@ plot2.default = function(
   if (is.null(xlab)) xlab = x_dep
   if (is.null(ylab)) ylab = y_dep
     
+  if (type == "area") {
+    ymax = y
+    ymin = rep.int(0, length(y))
+    type = "ribbon"
+  }
+
   xlabs = NULL
   if (type %in% c("pointrange", "errorbar", "ribbon")) {
     if (is.character(x)) x = as.factor(x)
@@ -375,12 +381,6 @@ plot2.default = function(
       ymax = ymax[xord]
       rm(xord)
     }
-  }
-
-  if (type == "area") {
-    ymax = y
-    ymin = rep.int(0, length(y))
-    type = "ribbon"
   }
 
   if (is.null(xlim)) xlim = range(x, na.rm = TRUE)

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -328,6 +328,12 @@ plot2.default = function(
     if (is.null(fargs[["legend.args"]][["title"]])) {
       fargs[["legend.args"]][["title"]] = by_dep
     }
+    ## Another catch for bespoke legend position (if originally passed via the formula method)
+    if (!is.null(fargs[["legend"]]) && !is.null(fargs[["legend.args"]])) {
+      if (names(fargs[["legend"]])[1] == "") names(fargs[["legend"]])[1] = "x"
+      fargs[["legend.args"]] = modifyList(fargs[["legend"]], fargs[["legend.args"]])
+      fargs[["legend"]] = NULL
+    }
     fargs$y = fargs$ymin = fargs$ymax = fargs$ylab = fargs$xlab = NULL
     return(do.call(plot2.density, args = fargs))
   }
@@ -335,7 +341,7 @@ plot2.default = function(
   if (is.null(y)) {
     ## Special catch for interval plots without a specified y-var
     if (type %in% c("pointrange", "errorbar", "ribbon")) {
-      ymin_dep = deparse(substitute(ymin)) 
+      ymin_dep = deparse(substitute(ymin))
       ymax_dep = deparse(substitute(ymax))
       y_dep = paste0("[", ymin_dep, ", ", ymax_dep, "]")
       y = rep(NA, length(x))

--- a/man/plot2.Rd
+++ b/man/plot2.Rd
@@ -71,7 +71,7 @@ plot2(x, ...)
 \method{plot2}{density}(
   x = NULL,
   by = NULL,
-  type = c("l", "ribbon"),
+  type = c("l", "area"),
   xlim = NULL,
   ylim = NULL,
   main = NULL,
@@ -113,8 +113,10 @@ for lines, "b" for both points and lines, "c" for empty points joined by
 lines, "o" for overplotted points and lines, "s" and "S" for stair steps
 and "h" for histogram-like vertical lines. "n" does not produce
 any points or lines.
-\item Additional plot2 types: "density" for drawing density plots, and
-"pointrange", "errorbar" or "ribbon" for drawing interval plots.
+\item Additional plot2 types: "density" for densities, "pointrange" or
+"errorbar" for segement intervals, and "ribbon" or "area" for polygon
+intervals (where area plots are a special case of ribbon plots with \code{ymin}
+set to 0 and \code{ymax} set to \code{y}; see below).
 }}
 
 \item{xlim}{the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
@@ -220,7 +222,7 @@ features are deferred to some other graphical parameter (i.e., passing the
 "by" keyword to one of \code{pch}, \code{lty}, or \code{bg}; see below.)}
 
 \item{bg}{background fill color for the open plot symbols 21:25 (see
-\code{points.default}), as well as ribbon plots types. For the latter
+\code{points.default}), as well as ribbon and area plot types. For the latter
 group---including filled density plots---an automatic alpha transparency
 adjustment will be applied (see the \code{ribbon_alpha} argument further below).
 Users can also supply a special \code{bg = "by"} convenience argument, in which


### PR DESCRIPTION
Closes #67.

(I also fixed a bug related to bespoke legends when passing to plot2.density via the one-sided formula method... but that's supplemental to the main purpose of the PR.)

Some quick examples.

``` r
devtools::load_all("~/Documents/Projects/plot2")
#> ℹ Loading plot2

plot2(sin(seq(0,10, .1)), type = "area")
```

![](https://i.imgur.com/Zy7guhO.png)<!-- -->

``` r

plot2(mpg ~ wt, mtcars, type = "area")
```

![](https://i.imgur.com/XpLfD4o.png)<!-- -->

And then some fancier examples because we can (TM).

``` r

par(las = 1)

plot2(
    ~Temp, airquality,
    type = "area",
    col = "darkcyan",
    grid = TRUE, frame = FALSE
)
```

![](https://i.imgur.com/57rv82b.png)<!-- -->

``` r

plot2(
    ~ Temp | Month, airquality,
    type = "area",
    grid = TRUE, frame = FALSE
)
```

![](https://i.imgur.com/sUwcoOB.png)<!-- -->
