### PR TITLE
Handling of grid = TRUE

### DIFF
--- a/R/plot2.R
+++ b/R/plot2.R
@@ -670,11 +670,11 @@ plot2.default = function(
         if (isTRUE(grid)) {
           gnx = gny = NULL
           if (!par("xlog")) {
-            graphics::abline(v = pretty(grDevices::extendrange(x)), col = "lightgray", lty = "dotted")
+            graphics::abline(v = pretty(grDevices::extendrange(x)), col = "lightgray", lty = "dotted", lwd = par("lwd"))
             gnx = NA
           }
           if (!par("ylog")) {
-            graphics::abline(h = pretty(grDevices::extendrange(y)), col = "lightgray", lty = "dotted")
+            graphics::abline(h = pretty(grDevices::extendrange(y)), col = "lightgray", lty = "dotted", lwd = par("lwd"))
             gny = NA
           }
           grid(nx = gnx, ny = gny)

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -669,11 +669,11 @@ plot2.default = function(
       if (is.logical(grid)) {
         if (isTRUE(grid)) {
           gnx = gny = NULL
-          if (inherits(x, c("Date", "POSIXlt", "POSIXct"))) {
+          if (!par("xlog")) {
             graphics::abline(v = pretty(grDevices::extendrange(x)), col = "lightgray", lty = "dotted")
             gnx = NA
           }
-          if (inherits(y, c("Date", "POSIXlt", "POSIXct"))) {
+          if (!par("ylog")) {
             graphics::abline(h = pretty(grDevices::extendrange(y)), col = "lightgray", lty = "dotted")
             gny = NA
           }

--- a/R/plot2.R
+++ b/R/plot2.R
@@ -667,6 +667,10 @@ plot2.default = function(
     if (frame.plot) box()
     if (!is.null(grid)) {
       if (is.logical(grid)) {
+        ## If grid is TRUE create a default grid. Rather than just calling the default grid()
+        ## abline(... = pretty(extendrange(...)), ...) is used. Reason: pretty() is generic
+        ## and works better for axes based on date/time classes. Exception: For axes in logs,
+        ## resort to using grid() which is like handled better there.
         if (isTRUE(grid)) {
           gnx = gny = NULL
           if (!par("xlog")) {


### PR DESCRIPTION
If `grid = TRUE` is specified, then the new `abline(... = pretty(extendrange(...)), ...)` is used now instead of `grid()` - and not just for date/time classes (see https://github.com/grantmcdermott/plot2/issues/77).

Reason: Unlike `grid()`, the function `pretty()` is generic. Thus, it can adapt better to axes for variables of other classes.

Only exception: For axes in logs, we still resort to using `grid()` which is likely handled better there.

Potential downside: In all cases I tried, the `pretty(extendrange(...))` approach yielded the same grid positions as `grid()`. But there may be situations when differences occur. However, in the examples I tried, I wasn't able to produce such a situation.