### PR TITLE
Setup GHA workflow for `altdoc`

### DIFF
--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -43,9 +43,8 @@ jobs:
 
       - name: Build site
         run: |
-          future::plan(future::multicore)
           install.packages(".", repos = NULL, type = "source")
-          altdoc::render_docs(parallel = TRUE, freeze = FALSE)
+          altdoc::render_docs(freeze = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,6 @@ Suggests:
   altdoc,
   basetheme,
   fontquiver,
-  future.apply,
   rsvg,
   svglite,
   tinytest,


### PR DESCRIPTION
This will render the docs in the branch `gh-pages` every time something is pushed to `main`. 

You can change the branch to which changes are pushed at the bottom of the yaml file, but I don't recommend that because pushing to `main` means that you and others will always need to update your local repo with the latest docs rendering. Using `gh-pages` will also allow to remove the `docs` folder from `main`.

This deployment works on my fork and takes about 2min in total.

Not sure you want that, I'm just proposing :)