### PR TITLE
Fix duplicate words in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris)             # formu
 <img src="man/figures/README-quickstart2-1.png" style="width:70.0%" />
 
 If you would prefer to save on a few keystrokes, you can use the
-shorthand `plt()` alias instead instead of typing out `tinyplot()` in
+shorthand `plt()` alias instead of typing out `tinyplot()` in
 full. Here’s the same plot with this shorthand alias, plus a few
 aesthetic tweaks:
 
@@ -120,7 +120,7 @@ plt(Sepal.Length ~ Petal.Length | Species, data = iris)
 style="width:70.0%" />
 
 Themes are persistent and will be applied to subsequent plots. For
-example, here is a grouped grouped density plot:
+example, here is a grouped density plot:
 
 ``` r
 plt(


### PR DESCRIPTION
Hi, 

I found some duplicate words in Readme.md. I didn't know if i should change `.md` or `.qmd`.

Have a nice day