### PR TITLE
Remove duplicated `swap_columns()`

### DIFF
--- a/R/flip.R
+++ b/R/flip.R
@@ -8,15 +8,6 @@ swap_elements = function(env, a, b) {
 }
 
 
-swap_columns = function(dp, a, b) {
-  va = dp[[a]]
-  vb = dp[[b]]
-  dp[[a]] = if (!is.null(vb)) vb else NULL
-  dp[[b]] = if (!is.null(va)) va else NULL
-  dp
-}
-
-
 flip_datapoints = function(settings) {
   env2env(settings, environment(), c("flip", "type", "datapoints", "log"))
 


### PR DESCRIPTION
Hi, I tested a new linter rule on this package and found that `swap_columns()` was defined once in `flip.R` and once in `utils.R`, with the same implementation. I removed the former (just because I had to pick one).