### PR TITLE
Issue 555

### DIFF
--- a/R/facet.R
+++ b/R/facet.R
@@ -311,8 +311,9 @@ draw_facet_window = function(
         # individual facet.
         xfree = if (!is.null(facet)) split(c(x, xmin, xmax), facet)[[ii]] else c(x, xmin, xmax)
         yfree = if (!is.null(facet)) split(c(y, ymin, ymax), facet)[[ii]] else c(y, ymin, ymax)
-        if (null_xlim) xlim = range(xfree, na.rm = TRUE)
-        if (null_ylim) ylim = range(yfree, na.rm = TRUE)
+        lim = calc_lim(range(xfree, na.rm = TRUE), range(yfree, na.rm = TRUE), asp)
+        if (null_xlim) xlim = lim$xlim
+        if (null_ylim) ylim = lim$ylim
         xext = extendrange(xlim, f = 0.04)
         yext = extendrange(ylim, f = 0.04)
         # We'll save this in a special .fusr env var (list) that we'll re-use

--- a/R/facet.R
+++ b/R/facet.R
@@ -230,6 +230,10 @@ draw_facet_window = function(
       mfgj = ii %% nfacet_cols
       if (mfgj == 0) mfgj = nfacet_cols
       par(mfg = c(mfgi, mfgj))
+      if (ii == 1) {
+        xin = grconvertX(1, "npc", "inches")
+        yin = grconvertY(1, "npc", "inches")
+      }
     }
 
     ## Set the plot window
@@ -311,7 +315,7 @@ draw_facet_window = function(
         # individual facet.
         xfree = if (!is.null(facet)) split(c(x, xmin, xmax), facet)[[ii]] else c(x, xmin, xmax)
         yfree = if (!is.null(facet)) split(c(y, ymin, ymax), facet)[[ii]] else c(y, ymin, ymax)
-        lim = calc_lim(range(xfree, na.rm = TRUE), range(yfree, na.rm = TRUE), asp)
+        lim = calc_lim(range(xfree, na.rm = TRUE), range(yfree, na.rm = TRUE), asp, xin, yin)
         if (null_xlim) xlim = lim$xlim
         if (null_ylim) ylim = lim$ylim
         xext = extendrange(xlim, f = 0.04)

--- a/R/lim.R
+++ b/R/lim.R
@@ -47,3 +47,32 @@ lim_args = function(settings) {
     c("xlim", "ylim", "xlabs", "ylabs", "xaxb", "yaxb")
   )
 }
+
+# translated from C_plot_window function in r-source/src/library/graphics/src/plot.c
+calc_lim <- function(
+  xlim,
+  ylim,
+  asp,
+  xin = grconvertX(1, "npc", "inches"),
+  yin = grconvertY(1, "npc", "inches")
+) {
+  if (!is.null(asp) && !is.na(asp) && asp > 0) {
+    xmin = xlim[1]; xmax = xlim[2]; ymin = ylim[1]; ymax = ylim[2];
+    xdelta = abs(xmax - xmin) / asp
+    ydelta = abs(ymax - ymin)
+    if(xdelta == 0.0 && ydelta == 0.0) {
+      # Not from R source: actual zero used here
+      return(list(xlim = xlim, ylim = ylim))
+    }
+    scale = min(c(xin / xdelta, yin / ydelta))
+    xadd = .5 * (xin / scale - xdelta) * asp
+    yadd = .5 * (yin / scale - ydelta)
+    if (xmax < xmin) xadd = xadd * -1
+    if (ymax < ymin) yadd = yadd * -1
+    return(list(
+      xlim = c(xmin - xadd, xmax + xadd),
+      ylim = c(ymin - yadd, ymax + yadd)
+    ))
+  }
+  list(xlim = xlim, ylim = ylim)
+}

--- a/inst/tinytest/_tinysnapshot/facet_free_asp_1.svg
+++ b/inst/tinytest/_tinysnapshot/facet_free_asp_1.svg
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8MjUwLjU2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='191.52' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8MjUwLjU2fDU5LjA0fDQzMC41Ng==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='83.87' y1='430.56' x2='225.73' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='83.87' y1='430.56' x2='83.87' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='119.33' y1='430.56' x2='119.33' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='154.80' y1='430.56' x2='154.80' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='190.27' y1='430.56' x2='190.27' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='225.73' y1='430.56' x2='225.73' y2='437.76' style='stroke-width: 0.75;' />
+<text x='83.87' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='119.33' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='154.80' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='190.27' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='225.73' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='59.04' y1='360.07' x2='59.04' y2='94.07' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='360.07' x2='51.84' y2='360.07' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='271.40' x2='51.84' y2='271.40' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='182.73' x2='51.84' y2='182.73' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='94.07' x2='51.84' y2='94.07' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,360.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-5</text>
+<text transform='translate(41.76,271.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,182.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,94.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<rect x='59.04' y='43.20' width='191.52' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='154.80' y='53.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>A</text>
+<polygon points='59.04,430.56 250.56,430.56 250.56,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMjgyLjI0fDQ3My43Nnw1OS4wNHw0MzAuNTY='>
+    <rect x='282.24' y='59.04' width='191.52' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjgyLjI0fDQ3My43Nnw1OS4wNHw0MzAuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='307.07' y1='430.56' x2='448.93' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='307.07' y1='430.56' x2='307.07' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='342.53' y1='430.56' x2='342.53' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='378.00' y1='430.56' x2='378.00' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='413.47' y1='430.56' x2='413.47' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='448.93' y1='430.56' x2='448.93' y2='437.76' style='stroke-width: 0.75;' />
+<text x='307.07' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='342.53' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='378.00' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='413.47' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='448.93' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='282.24' y1='360.07' x2='282.24' y2='94.07' style='stroke-width: 0.75;' />
+<line x1='282.24' y1='360.07' x2='275.04' y2='360.07' style='stroke-width: 0.75;' />
+<line x1='282.24' y1='271.40' x2='275.04' y2='271.40' style='stroke-width: 0.75;' />
+<line x1='282.24' y1='182.73' x2='275.04' y2='182.73' style='stroke-width: 0.75;' />
+<line x1='282.24' y1='94.07' x2='275.04' y2='94.07' style='stroke-width: 0.75;' />
+<text transform='translate(264.96,360.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-5</text>
+<text transform='translate(264.96,271.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(264.96,182.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(264.96,94.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<rect x='282.24' y='43.20' width='191.52' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='378.00' y='53.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>B</text>
+<polygon points='282.24,430.56 473.76,430.56 473.76,59.04 282.24,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpNTkuMDR8MjUwLjU2fDU5LjA0fDQzMC41Ng==)'>
+<polyline points='83.87,253.67 66.13,253.67 66.13,235.93 83.87,235.93 83.87,253.67 83.87,244.80 243.47,244.80 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMjgyLjI0fDQ3My43Nnw1OS4wNHw0MzAuNTY=)'>
+<polyline points='307.07,253.67 289.33,253.67 289.33,235.93 307.07,235.93 307.07,253.67 307.07,244.80 466.67,244.80 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMTAyLjI0fDQ1OS4zNnw4Ny44NHwzNzIuOTY='>
+    <rect x='102.24' y='87.84' width='357.12' height='285.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAyLjI0fDQ1OS4zNnw4Ny44NHwzNzIuOTY=)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-facet.R
+++ b/inst/tinytest/test-facet.R
@@ -513,6 +513,22 @@ f = function() {
 }
 expect_snapshot_plot(f, label = "facet_free_grid")
 
+f = function() {
+  tinyplot(
+    y ~ x,
+    facet = ~group,
+    facet.args = list(free = TRUE),
+    data = data.frame(
+      y = rep(c(1, 1, 2, 2, 1, 1.5, 1.5), 2),
+      x = rep(c(2, 1, 1, 2, 2, 2, 11), 2),
+      group = c(rep("A", 7), rep("B", 7))
+    ),
+    type = "l",
+    asp = 1
+  )
+}
+expect_snapshot_plot(f, label = "facet_free_asp_1")
+
 #
 # restore original par settings
 #


### PR DESCRIPTION
I've made an attempt to solve issue #555 , but it's not quite working. The plot I'm getting looks like this:

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/4d0624d7-3d3b-481c-bbed-53aa84f1f5c8" />

<details> <summary> diff plot </summary>

<img width="1512" height="504" alt="image" src="https://github.com/user-attachments/assets/8c1dd7ad-ae4c-4dd2-9dd6-51277b5d2e52" />

</details>

So pane A is almost right and pane B is further off.

I've diagnosed that when `usr` is set manually, `asp` is not taken into account. https://github.com/grantmcdermott/tinyplot/blob/ba467917db69f25160a07f65cc6c5d249a628082/R/facet.R#L325-L328

I've attempted to translate [the logic used by plot.window()](https://github.com/wch/r-source/blob/8fec469cb5de80c3e6d7feae4d906180a39c5426/src/library/graphics/src/plot.c#L548-L575). However, it's not working. I believe the issue is that `grconvertX(1, "npc", "inches")` is not actually equivalent to `GConvertXUnits(1.0, NPC, INCHES, dd)` or maybe I'm calling `grconvertX` in the wrong context.