### PR TITLE
issue570

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,9 @@ where the formatting is also better._
   or character inputs (e.g., `grid = TRUE`, `grid = "xy"`) remain the more
   idiomatic way to generate a background grid in `tinyplot`.
   (#193 @grantmcdermott)
+- Fixed margin spacing for free facets with different axis scales. The dynamic
+  margin adjustment now computes tick labels per-facet and sizes the margin to
+  accommodate the widest labels. (#579 @grantmcdermott)
 
 ## v0.6.1
 

--- a/R/facet.R
+++ b/R/facet.R
@@ -145,8 +145,14 @@ draw_facet_window = function(
           yaxlabs = if (!is.null(names(ylabs))) names(ylabs) else ylabs 
         } else if (type == "boxplot" && isTRUE(flip) && !is.null(xlabs)) {
           yaxlabs = if (!is.null(names(xlabs))) names(xlabs) else xlabs 
+        } else if (isTRUE(facet.args[["free"]]) && null_ylim && !is.null(facet)) {
+          yfree_split = split(c(y, ymin, ymax), facet)
+          yaxlabs_all = lapply(yfree_split, function(yf) {
+            axisTicks(usr = extendrange(range(yf, na.rm = TRUE), f = 0.04), log = par("ylog"))
+          })
+          widths = vapply(yaxlabs_all, function(labs) max(strwidth(labs, "inches")), numeric(1L))
+          yaxlabs = yaxlabs_all[[which.max(widths)]]
         } else {
-          # yaxl = axTicks(2)
           yaxlabs = axisTicks(usr = extendrange(ylim, f = 0.04), log = par("ylog"))
         }
         if (!is.null(yaxl)) yaxlabs = tinylabel(yaxlabs, yaxl)
@@ -163,9 +169,17 @@ draw_facet_window = function(
       }
       if (par("las") %in% 2:3) {
         # extra whitespace bump on the x axis
-        # xaxlabs = axTicks(1)
-        xaxlabs = if (is.null(xlabs)) axisTicks(usr = extendrange(xlim, f = 0.04), log = par("xlog")) else 
-          if (!is.null(names(xlabs))) names(xlabs) else xlabs
+        if (is.null(xlabs) && isTRUE(facet.args[["free"]]) && null_xlim && !is.null(facet)) {
+          xfree_split = split(c(x, xmin, xmax), facet)
+          xaxlabs_all = lapply(xfree_split, function(xf) {
+            axisTicks(usr = extendrange(range(xf, na.rm = TRUE), f = 0.04), log = par("xlog"))
+          })
+          widths = vapply(xaxlabs_all, function(labs) max(strwidth(labs, "inches")), numeric(1L))
+          xaxlabs = xaxlabs_all[[which.max(widths)]]
+        } else {
+          xaxlabs = if (is.null(xlabs)) axisTicks(usr = extendrange(xlim, f = 0.04), log = par("xlog")) else
+            if (!is.null(names(xlabs))) names(xlabs) else xlabs
+        }
         if (!is.null(xaxl)) xaxlabs = tinylabel(xaxlabs, xaxl)
         whtsbp = grconvertX(max(strwidth(xaxlabs, "figure")), from = "nfc", to = "lines") - 1
         if (whtsbp > 0) {

--- a/inst/tinytest/_tinysnapshot/facet_free_yscale.svg
+++ b/inst/tinytest/_tinysnapshot/facet_free_yscale.svg
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='66.82' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='202.36px' lengthAdjust='spacingAndGlyphs'>Free facets: different y scales</text>
+<text x='281.09' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(12.96,242.78) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+</g>
+<defs>
+  <clipPath id='cpNzkuODJ8MjUyLjAwfDU3Ljg5fDQ1Ni40OA=='>
+    <rect x='79.82' y='57.89' width='172.18' height='398.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzkuODJ8MjUyLjAwfDU3Ljg5fDQ1Ni40OA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='86.20' y1='456.48' x2='245.62' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='86.20' y1='456.48' x2='86.20' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='118.08' y1='456.48' x2='118.08' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='149.97' y1='456.48' x2='149.97' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='181.85' y1='456.48' x2='181.85' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='213.74' y1='456.48' x2='213.74' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='245.62' y1='456.48' x2='245.62' y2='460.80' style='stroke-width: 0.75;' />
+<text x='86.20' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='118.08' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='149.97' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='181.85' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='213.74' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='245.62' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='79.82' y1='441.72' x2='79.82' y2='72.65' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='441.72' x2='75.50' y2='441.72' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='367.90' x2='75.50' y2='367.90' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='294.09' x2='75.50' y2='294.09' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='220.28' x2='75.50' y2='220.28' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='146.46' x2='75.50' y2='146.46' style='stroke-width: 0.75;' />
+<line x1='79.82' y1='72.65' x2='75.50' y2='72.65' style='stroke-width: 0.75;' />
+<text x='69.74' y='445.85' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='69.74' y='372.03' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='69.74' y='298.22' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='69.74' y='224.41' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='69.74' y='150.59' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='69.74' y='76.78' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<rect x='79.82' y='42.05' width='172.18' height='15.84' style='stroke-width: 0.75; fill: #E5E5E5;' />
+<text x='165.91' y='52.13' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>A</text>
+<polygon points='79.82,456.48 252.00,456.48 252.00,57.89 79.82,57.89 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpNzkuODJ8MjUyLjAwfDU3Ljg5fDQ1Ni40OA==)'>
+<line x1='86.20' y1='456.48' x2='86.20' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='118.08' y1='456.48' x2='118.08' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='149.97' y1='456.48' x2='149.97' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='181.85' y1='456.48' x2='181.85' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='213.74' y1='456.48' x2='213.74' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='245.62' y1='456.48' x2='245.62' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='441.72' x2='252.00' y2='441.72' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='367.90' x2='252.00' y2='367.90' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='294.09' x2='252.00' y2='294.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='220.28' x2='252.00' y2='220.28' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='146.46' x2='252.00' y2='146.46' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='79.82' y1='72.65' x2='252.00' y2='72.65' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+</g>
+<defs>
+  <clipPath id='cpMzE1Ljk4fDQ4OC4xNnw1Ny44OXw0NTYuNDg='>
+    <rect x='315.98' y='57.89' width='172.18' height='398.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzE1Ljk4fDQ4OC4xNnw1Ny44OXw0NTYuNDg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='322.36' y1='456.48' x2='481.78' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='322.36' y1='456.48' x2='322.36' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='354.24' y1='456.48' x2='354.24' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='386.13' y1='456.48' x2='386.13' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='418.01' y1='456.48' x2='418.01' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='449.90' y1='456.48' x2='449.90' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='481.78' y1='456.48' x2='481.78' y2='460.80' style='stroke-width: 0.75;' />
+<text x='322.36' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='354.24' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='386.13' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='418.01' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='449.90' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='481.78' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='315.98' y1='441.72' x2='315.98' y2='72.65' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='441.72' x2='311.66' y2='441.72' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='367.90' x2='311.66' y2='367.90' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='294.09' x2='311.66' y2='294.09' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='220.28' x2='311.66' y2='220.28' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='146.46' x2='311.66' y2='146.46' style='stroke-width: 0.75;' />
+<line x1='315.98' y1='72.65' x2='311.66' y2='72.65' style='stroke-width: 0.75;' />
+<text x='305.90' y='445.85' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000000</text>
+<text x='305.90' y='372.03' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000002</text>
+<text x='305.90' y='298.22' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000004</text>
+<text x='305.90' y='224.41' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000006</text>
+<text x='305.90' y='150.59' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000008</text>
+<text x='305.90' y='76.78' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.70px' lengthAdjust='spacingAndGlyphs'>1000010</text>
+<rect x='315.98' y='42.05' width='172.18' height='15.84' style='stroke-width: 0.75; fill: #E5E5E5;' />
+<text x='402.07' y='52.13' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>B</text>
+<polygon points='315.98,456.48 488.16,456.48 488.16,57.89 315.98,57.89 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMzE1Ljk4fDQ4OC4xNnw1Ny44OXw0NTYuNDg=)'>
+<line x1='322.36' y1='456.48' x2='322.36' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='354.24' y1='456.48' x2='354.24' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='386.13' y1='456.48' x2='386.13' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='418.01' y1='456.48' x2='418.01' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='449.90' y1='456.48' x2='449.90' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='481.78' y1='456.48' x2='481.78' y2='57.89' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='441.72' x2='488.16' y2='441.72' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='367.90' x2='488.16' y2='367.90' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='294.09' x2='488.16' y2='294.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='220.28' x2='488.16' y2='220.28' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='146.46' x2='488.16' y2='146.46' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.98' y1='72.65' x2='488.16' y2='72.65' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+</g>
+<g clip-path='url(#cpNzkuODJ8MjUyLjAwfDU3Ljg5fDQ1Ni40OA==)'>
+<circle cx='86.20' cy='441.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='102.14' cy='404.81' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='118.08' cy='367.90' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='134.03' cy='331.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='149.97' cy='294.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='165.91' cy='257.18' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='181.85' cy='220.28' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='197.80' cy='183.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='213.74' cy='146.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='229.68' cy='109.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='245.62' cy='72.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<g clip-path='url(#cpMzE1Ljk4fDQ4OC4xNnw1Ny44OXw0NTYuNDg=)'>
+<circle cx='322.36' cy='441.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='338.30' cy='404.81' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='354.24' cy='367.90' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='370.19' cy='331.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='386.13' cy='294.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='402.07' cy='257.18' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='418.01' cy='220.28' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='433.96' cy='183.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='449.90' cy='146.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='465.84' cy='109.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='481.78' cy='72.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<defs>
+  <clipPath id='cpOTAuNzJ8NDczLjc2fDg2LjY5fDM5OC44OA=='>
+    <rect x='90.72' y='86.69' width='383.04' height='312.19' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOTAuNzJ8NDczLjc2fDg2LjY5fDM5OC44OA==)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-facet.R
+++ b/inst/tinytest/test-facet.R
@@ -513,6 +513,22 @@ f = function() {
 }
 expect_snapshot_plot(f, label = "facet_free_grid")
 
+# Free facets with different y-axis scales (issue #570)
+f = function() {
+  dat = data.frame(
+    x = rep(0:10, times = 2),
+    y = c(0:10, 1000000:1000010),
+    f = rep(c("A", "B"), each = 11)
+  )
+  tinyplot(
+    y ~ x, data = dat,
+    facet = ~f, facet.args = list(free = TRUE),
+    theme = "clean",
+    main = "Free facets: different y scales"
+  )
+}
+expect_snapshot_plot(f, label = "facet_free_yscale")
+
 #
 # restore original par settings
 #


### PR DESCRIPTION
Fixes #570

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot

# Decimal precision difference 
dat = data.frame(
  x_variable = rep(c(0, 10), times = 4),
  y_variable = c(0.707, 0.708, 0.711, 0.704, 0.293, 0.292, 0.289, 0.297),
  f_variable = rep(c("A", "B"), each = 4)
)

plt(
  y_variable ~ x_variable, 
  facet = ~ f_variable, facet.args = list(free = TRUE),
  data = dat,
  theme = 'clean'
)
```

![](https://i.imgur.com/zLx3QHz.png)<!-- -->

One minor bummer is that the vastly different scales can lead to "unecessary" spacing adjustment for the smaller subsets (e.g., LHS facet below). But I think it's better to be consistent in facet sizing, not to mention much simpler to use a single `par("mar")` adjustment.

``` r
# Scale difference between facets                                                                         
dat = data.frame(
  x_variable = rep(0:10, times = 2),
  y_variable = c(0:10, 1000000:1000010),
  f_variable = rep(c("A", "B"), each = 11)
)

plt(
  y_variable ~ x_variable, 
  facet = ~ f_variable, facet.args = list(free = TRUE),
  data = dat,
  theme = 'clean'
)
```

![](https://i.imgur.com/bFLo3ia.png)<!-- -->

<sup>Created on 2026-05-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>