### PR TITLE
feat(theme): cex-aware dynamic margins and spacing primitives

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,4 +27,5 @@ Makefile
 ^.devcontainer
 Rplots.pdf
 ^CLAUDE\.md$
+^.claude/
 ^revdep$

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ README_files/
 inst/tinytest/_tinysnapshot_OLD/
 inst/tinytest/_tinysnapshot_review/
 
+# Claude Code
+.claude/
+
 # MacOS cruft
 .DS_Store
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ visualizations.
   logic. Recall, these are themes like `"dynamic"`, `"clean"`, `"bw"`, etc. that
   automatically adjust margin spacing and related plot elements to reduce
   whitespace and improve the overall plot aesthetic.
-  (#549 @grantmcdermott, @vincentarelbundock)
+  (#549, #591 @grantmcdermott, @vincentarelbundock)
   
   - Plot margins now correctly respond to missing and/or multi-line `main`,
     `sub`, and `x`/`y` axis titles. For example, a plot without a `main` (or
@@ -40,21 +40,33 @@ visualizations.
     more general `cex.lab` is still respected as a fallback. (#574)
   - Margin spacing now correctly adjusts for math expressions, including
     fractions and exponents in titles. (#575)
+  - Dynamic margins and `mgp` now scale correctly with `cex.axis` and
+    `cex.lab`, maintaining constant visual gaps between axis elements
+    regardless of text size. From the user perspective, this is
+    operationalized through the new `gap.axis` and `gap.lab` theme
+    primitives, which let you control the spacing between margin elements
+    directly (tick-to-label gap and label-to-title gap, respectively),
+    replacing the guesswork of manually combining `mar`, `mgp`, and `tcl`
+    values. (#590)
 
 ### New features
 
+- New `ljust` parameter for controlling legend title and label justification.
+  Accepts values of `"l(eft)"` (default) or `"c(enter")`. Can be set per-plot
+  via `legend = list(..., ljust = "c")`, or globally via `tpar(ljust = "c")`.
+  (#500 @grantmcdermott)
+- New `"dynamic"` theme that now serves as the foundation for all other dynamic
+  (tiny)themes. (#549 @grantmcdermott)
 - The `grid` argument (and `tpar("grid")`) now accepts character strings to
   control axis-specific grids at different resolutions. Uppercase letters
   (`"X"`, `"Y"`, `"XY"`) draw grid lines at the standard tick positions, while
   lowercase letters (`"x"`, `"y"`, `"xy"`) draw a finer grid with additional
   lines at the midpoints between ticks. Thanks to @zeileis for the suggestion.
   (#578 @grantmcdermott)
-- New `ljust` parameter for controlling legend title and label justification.
-  Accepts values of `"l(eft)"` (default) or `"c(enter")`. Can be set per-plot
-  via `legend = list(..., ljust = "c")`, or globally via `tpar(ljust = "c")`.
-  (#500 @grantmcdermott)
-- New `"dynamic"` theme that now serves as the foundation for all other dynamic
-  (tiny)themes. (#549 @grantmcdermott) 
+- `tinytheme()` now accepts additional `gap.axis` and `gap.lab` "primitives",
+  providing finer control for spacing between ticks-labels and labels-titles,
+  respectively, in dynamic themes. See the **Dynamic themes** entry above.
+  (#590 @grantmcdermott)
 
 ### Bug fixes
 

--- a/R/facet.R
+++ b/R/facet.R
@@ -144,14 +144,14 @@ draw_facet_window = function(
           yaxlabs_all = lapply(yfree_split, function(yf) {
             axisTicks(usr = extendrange(range(yf, na.rm = TRUE), f = 0.04), log = par("ylog"))
           })
-          widths = vapply(yaxlabs_all, function(labs) max(strwidth(labs, "inches")), numeric(1L))
+          widths = vapply(yaxlabs_all, function(labs) max(strwidth(labs, "inches", cex = par("cex.axis"))), numeric(1L))
           yaxlabs = yaxlabs_all[[which.max(widths)]]
         } else {
           yaxlabs = axisTicks(usr = extendrange(ylim, f = 0.04), log = par("ylog"))
         }
         if (!is.null(yaxl)) yaxlabs = tinylabel(yaxlabs, yaxl)
         # whtsbp = grconvertX(max(strwidth(yaxl, "figure")), from = "nfc", to = "lines") - 1
-        whtsbp = grconvertX(max(strwidth(yaxlabs, "figure")), from = "nfc", to = "lines") - grconvertX(0, from = "nfc", to = "lines") - 1
+        whtsbp = grconvertX(max(strwidth(yaxlabs, "figure", cex = par("cex.axis"))), from = "nfc", to = "lines") - grconvertX(0, from = "nfc", to = "lines") - 1
         if (whtsbp > 0) {
           omar = omar + c(0, whtsbp, 0, 0) * cex_fct_adj
           fmar[2] = fmar[2] + whtsbp * cex_fct_adj
@@ -168,14 +168,14 @@ draw_facet_window = function(
           xaxlabs_all = lapply(xfree_split, function(xf) {
             axisTicks(usr = extendrange(range(xf, na.rm = TRUE), f = 0.04), log = par("xlog"))
           })
-          widths = vapply(xaxlabs_all, function(labs) max(strwidth(labs, "inches")), numeric(1L))
+          widths = vapply(xaxlabs_all, function(labs) max(strwidth(labs, "inches", cex = par("cex.axis"))), numeric(1L))
           xaxlabs = xaxlabs_all[[which.max(widths)]]
         } else {
           xaxlabs = if (is.null(xlabs)) axisTicks(usr = extendrange(xlim, f = 0.04), log = par("xlog")) else
             if (!is.null(names(xlabs))) names(xlabs) else xlabs
         }
         if (!is.null(xaxl)) xaxlabs = tinylabel(xaxlabs, xaxl)
-        whtsbp = grconvertX(max(strwidth(xaxlabs, "figure")), from = "nfc", to = "lines") - 1
+        whtsbp = grconvertX(max(strwidth(xaxlabs, "figure", cex = par("cex.axis"))), from = "nfc", to = "lines") - 1
         if (whtsbp > 0) {
           omar = omar + c(whtsbp, 0, 0, 0) * cex_fct_adj
           fmar[1] = fmar[1] + whtsbp * cex_fct_adj
@@ -236,8 +236,8 @@ draw_facet_window = function(
         yaxlabs = axisTicks(usr = extendrange(ylim, f = 0.04), log = par("ylog"))
       }
       if (!is.null(yaxl)) yaxlabs = tinylabel(yaxlabs, yaxl)
-      # whtsbp = grconvertX(max(strwidth(yaxlabs, "figure")), from = "nfc", to = "lines") - 1
-      whtsbp = grconvertX(max(strwidth(yaxlabs, "figure")), from = "nfc", to = "lines") - grconvertX(0, from = "nfc", to = "lines") - 1
+      # whtsbp = grconvertX(max(strwidth(yaxlabs, "figure", cex = par("cex.axis"))), from = "nfc", to = "lines") - 1
+      whtsbp = grconvertX(max(strwidth(yaxlabs, "figure", cex = par("cex.axis"))), from = "nfc", to = "lines") - grconvertX(0, from = "nfc", to = "lines") - 1
       if (whtsbp > 0) {
         omar[2] = omar[2] + whtsbp
       }
@@ -248,7 +248,7 @@ draw_facet_window = function(
       xaxlabs = if (is.null(xlabs)) axisTicks(usr = extendrange(xlim, f = 0.04), log = par("xlog")) else 
         if (!is.null(names(xlabs))) names(xlabs) else xlabs
       if (!is.null(xaxl)) xaxlabs = tinylabel(xaxlabs, xaxl)
-      whtsbp = grconvertX(max(strwidth(xaxlabs, "figure")), from = "nfc", to = "lines") - 1
+      whtsbp = grconvertX(max(strwidth(xaxlabs, "figure", cex = par("cex.axis"))), from = "nfc", to = "lines") - 1
       if (whtsbp > 0) {
         omar[1] = omar[1] + whtsbp
       }

--- a/R/facet.R
+++ b/R/facet.R
@@ -313,11 +313,13 @@ draw_facet_window = function(
         lwd = get_tpar(c("lwd.xaxs", "lwd.axis"), 1, tpar_list = tpars),
         lty = get_tpar(c("lty.xaxs", "lty.axis"), 1, tpar_list = tpars)
       )
+      .ca = get_tpar(c("cex.yaxs", "cex.axis"), 0.8, tpar_list = tpars)
+      .ymgp_shift = if (par("las") %in% c(0L, 1L)) 0.5 * (.ca - 1) else 0
       args_y = list(y,
         side = yside,
         type = yaxt,
         labeller = yaxl,
-        cex = get_tpar(c("cex.yaxs", "cex.axis"), 0.8, tpar_list = tpars),
+        cex = .ca,
         lwd = get_tpar(c("lwd.yaxs", "lwd.axis"), 1, tpar_list = tpars),
         lty = get_tpar(c("lty.yaxs", "lty.axis"), 1, tpar_list = tpars)
       )
@@ -368,21 +370,27 @@ draw_facet_window = function(
         } else {
           tinyAxis(xfree, side = xside, type = xaxt, labeller = xaxl)
         }
+        if (.ymgp_shift > 0) par(mgp = par("mgp") - c(0, .ymgp_shift, 0))
         if (isTRUE(flip) && type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "p", "violin") && !is.null(ylabs)) {
           tinyAxis(yfree, side = yside, at = ylabs, labels = names(ylabs), type = yaxt, labeller = yaxl)
         } else {
           tinyAxis(yfree, side = yside, type = yaxt, labeller = yaxl)
         }
+        if (.ymgp_shift > 0) par(mgp = par("mgp") + c(0, .ymgp_shift, 0))
 
         # For fixed facets we can just reuse the same plot extent and axes limits
       } else if (isTRUE(frame.plot)) {
         # if plot frame is true then print axes per normal...
         do.call(tinyAxis, args_x)
+        if (.ymgp_shift > 0) par(mgp = par("mgp") - c(0, .ymgp_shift, 0))
         do.call(tinyAxis, args_y)
+        if (.ymgp_shift > 0) par(mgp = par("mgp") + c(0, .ymgp_shift, 0))
       } else {
         # ... else only print the "outside" axes.
         if (ii %in% oxaxis) do.call(tinyAxis, args_x)
+        if (.ymgp_shift > 0) par(mgp = par("mgp") - c(0, .ymgp_shift, 0))
         if (ii %in% oyaxis) do.call(tinyAxis, args_y)
+        if (.ymgp_shift > 0) par(mgp = par("mgp") + c(0, .ymgp_shift, 0))
       }
     }
 

--- a/R/legend.R
+++ b/R/legend.R
@@ -124,7 +124,7 @@ legend_outer_margins = function(legend_env, apply = TRUE) {
       if (legend_env$dynmar) {
         omar = par("mar")
         if (legend_env$outer_bottom) {
-          omar[1] = theme_dynamic$mgp[1] + 1 * par("cex.lab")
+          omar[1] = par("mgp")[1] + 1 * par("cex.lab")
           if (legend_env$has_sub && (is.null(.tpar[["side.sub"]]) || .tpar[["side.sub"]] == 1)) {
             omar[1] = omar[1] + 1 * par("cex.sub")
           }

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1058,7 +1058,8 @@ tinyplot.default = function(
     # Compute whtsbp (tick-label width/height bump). Read `las` from .tpars
     # (the theme definition) rather than par() — par("las") isn't set to the
     # theme's intended value until the before.plot.new hook fires, but this
-    # block runs before that.
+    # block runs before that. Pass .cex_axis to strwidth so measurements
+    # reflect the intended text size (par("cex.axis") isn't set yet either).
     .whtsbp = c(0, 0, 0, 0)
     .las = get_tpar("las", tpar_list = .tpars, default = par("las"))
     if (.las %in% 1:2) {
@@ -1072,7 +1073,7 @@ tinyplot.default = function(
         yaxlabs = axisTicks(usr = extendrange(ylim, f = 0.04), log = par("ylog"))
       }
       if (!is.null(yaxl)) yaxlabs = tinylabel(yaxlabs, yaxl)
-      whtsbp_y = grconvertX(max(strwidth(yaxlabs, "figure")), from = "nfc", to = "lines") -
+      whtsbp_y = grconvertX(max(strwidth(yaxlabs, "figure", cex = .cex_axis)), from = "nfc", to = "lines") -
                  grconvertX(0, from = "nfc", to = "lines") - 1
       if (is.finite(whtsbp_y) && whtsbp_y > 0) .whtsbp[2] = whtsbp_y
     }
@@ -1080,7 +1081,7 @@ tinyplot.default = function(
       xaxlabs = if (is.null(xlabs)) axisTicks(usr = extendrange(xlim, f = 0.04), log = par("xlog")) else
         if (!is.null(names(xlabs))) names(xlabs) else xlabs
       if (!is.null(xaxl)) xaxlabs = tinylabel(xaxlabs, xaxl)
-      whtsbp_x = grconvertX(max(strwidth(xaxlabs, "figure")), from = "nfc", to = "lines") - 1
+      whtsbp_x = grconvertX(max(strwidth(xaxlabs, "figure", cex = .cex_axis)), from = "nfc", to = "lines") - 1
       if (is.finite(whtsbp_x) && whtsbp_x > 0) .whtsbp[1] = whtsbp_x
     }
 
@@ -1437,7 +1438,7 @@ tinyplot.default = function(
         apar = par(no.readonly = TRUE)
         set_saved_par(when = "after", apar)
       },
-      list = list(), 
+      list = list(),
       env = getNamespace('tinyplot')
     )
   }

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -974,6 +974,7 @@ tinyplot.default = function(
   #
   dynmar_computed = NULL
   .whtsbp = c(0, 0, 0, 0)
+  .mgp_scaled = FALSE
   if (!add && isTRUE(get_tpar("dynmar"))) {
     .side.sub = get_tpar("side.sub", default = 3)
     # Read the theme's intended mar. Also build a tpars list from the theme
@@ -996,6 +997,28 @@ tinyplot.default = function(
       if (is.list(.bp)) .tpars = modifyList(.tpars, .bp)
     }
     if (!is.null(.tpars[["mar"]])) .theme_mar = .tpars[["mar"]]
+
+    # Dynamic mgp: scale mgp[1] and mgp[2] when cex.axis or cex.lab exceed 1.
+    # At cex=1 the theme's base mgp works. At larger cex, tick labels need more
+    # space to clear the plot edge (mgp[2] >= 0.5*cex_axis) and the title needs
+    # more separation from tick labels (mgp[1] >= mgp[2] + 0.4*cex_axis + 0.5*cex_lab).
+    .cex_axis = get_tpar("cex.axis", tpar_list = .tpars, default = 1)
+    .cex_lab = max(
+      get_tpar(c("cex.xlab", "cex.lab"), tpar_list = .tpars, default = 1),
+      get_tpar(c("cex.ylab", "cex.lab"), tpar_list = .tpars, default = 1)
+    )
+    .mgp = get_tpar("mgp", tpar_list = .tpars)
+    if (.cex_axis > 1 || .cex_lab > 1) {
+      .mgp2_min = 0.5 * .cex_axis
+      .mgp2 = max(.mgp[2], .mgp2_min)
+      .mgp1_min = .mgp2 + 0.4 * .cex_axis + 0.5 * .cex_lab
+      .mgp1 = max(.mgp[1], .mgp1_min)
+      if (.mgp1 != .mgp[1] || .mgp2 != .mgp[2]) {
+        .mgp = c(.mgp1, .mgp2, .mgp[3])
+        .tpars[["mgp"]] = .mgp
+        .mgp_scaled = TRUE
+      }
+    }
 
     # Detect outer-legend sides (order: bottom, left, top, right).
     .lgnd_pos = settings$legend_args[["x"]]
@@ -1070,6 +1093,7 @@ tinyplot.default = function(
 
     dynmar_computed = .theme_mar + .dyn
     par(mar = dynmar_computed + .whtsbp)
+    if (.mgp_scaled) par(mgp = .mgp)
   }
 
   if (legend_draw_flag) {
@@ -1126,6 +1150,7 @@ tinyplot.default = function(
     # (which may have called plot.new and reset par via hooks).
     if (!is.null(dynmar_computed)) {
       par(mar = dynmar_computed + .whtsbp)
+      if (.mgp_scaled) par(mgp = .mgp)
       if (!is.null(xlim) && !is.null(ylim)) {
         plot.window(xlim = xlim, ylim = ylim)
       }

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -974,7 +974,6 @@ tinyplot.default = function(
   #
   dynmar_computed = NULL
   .whtsbp = c(0, 0, 0, 0)
-  .mgp_scaled = FALSE
   if (!add && isTRUE(get_tpar("dynmar"))) {
     .side.sub = get_tpar("side.sub", default = 3)
     # Read the theme's intended mar. Also build a tpars list from the theme
@@ -998,27 +997,9 @@ tinyplot.default = function(
     }
     if (!is.null(.tpars[["mar"]])) .theme_mar = .tpars[["mar"]]
 
-    # Dynamic mgp: scale mgp[1] and mgp[2] when cex.axis or cex.lab exceed 1.
-    # At cex=1 the theme's base mgp works. At larger cex, tick labels need more
-    # space to clear the plot edge (mgp[2] >= 0.5*cex_axis) and the title needs
-    # more separation from tick labels (mgp[1] >= mgp[2] + 0.4*cex_axis + 0.5*cex_lab).
     .cex_axis = get_tpar("cex.axis", tpar_list = .tpars, default = 1)
-    .cex_lab = max(
-      get_tpar(c("cex.xlab", "cex.lab"), tpar_list = .tpars, default = 1),
-      get_tpar(c("cex.ylab", "cex.lab"), tpar_list = .tpars, default = 1)
-    )
-    .mgp = get_tpar("mgp", tpar_list = .tpars)
-    if (.cex_axis > 1 || .cex_lab > 1) {
-      .mgp2_min = 0.5 * .cex_axis
-      .mgp2 = max(.mgp[2], .mgp2_min)
-      .mgp1_min = .mgp2 + 0.4 * .cex_axis + 0.5 * .cex_lab
-      .mgp1 = max(.mgp[1], .mgp1_min)
-      if (.mgp1 != .mgp[1] || .mgp2 != .mgp[2]) {
-        .mgp = c(.mgp1, .mgp2, .mgp[3])
-        .tpars[["mgp"]] = .mgp
-        .mgp_scaled = TRUE
-      }
-    }
+    .las = get_tpar("las", tpar_list = .tpars, default = par("las"))
+    .ymgp_shift = if (.las %in% c(0L, 1L)) 0.5 * (.cex_axis - 1) else 0
 
     # Detect outer-legend sides (order: bottom, left, top, right).
     .lgnd_pos = settings$legend_args[["x"]]
@@ -1040,6 +1021,7 @@ tinyplot.default = function(
                   tpars = .tpars),
       dynmar_side(4, NULL, tpars = .tpars)
     )
+    if (.ymgp_shift > 0) .dyn[2] = .dyn[2] - .ymgp_shift
     # Drop the theme's baseline padding on outer-legend sides so the plot
     # region meets the legend's oma flush. Only .theme_mar is zeroed — the
     # axis-driven bumps in .dyn (tick rows, axis labels, main/sub) are kept
@@ -1094,7 +1076,6 @@ tinyplot.default = function(
 
     dynmar_computed = .theme_mar + .dyn
     par(mar = dynmar_computed + .whtsbp)
-    if (.mgp_scaled) par(mgp = .mgp)
   }
 
   if (legend_draw_flag) {
@@ -1151,14 +1132,13 @@ tinyplot.default = function(
     # (which may have called plot.new and reset par via hooks).
     if (!is.null(dynmar_computed)) {
       par(mar = dynmar_computed + .whtsbp)
-      if (.mgp_scaled) par(mgp = .mgp)
       if (!is.null(xlim) && !is.null(ylim)) {
         plot.window(xlim = xlim, ylim = ylim)
       }
     }
     draw_title(main, sub, xlab, ylab, legend, legend_args, opar,
                xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[1] else 0,
-               ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[2] else 0)
+               ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[2] - .ymgp_shift else 0)
   }
 
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -998,8 +998,10 @@ tinyplot.default = function(
     if (!is.null(.tpars[["mar"]])) .theme_mar = .tpars[["mar"]]
 
     .cex_axis = get_tpar("cex.axis", tpar_list = .tpars, default = 1)
+    .cex_lab = get_tpar(c("cex.ylab", "cex.lab"), tpar_list = .tpars, default = 1)
     .las = get_tpar("las", tpar_list = .tpars, default = par("las"))
     .ymgp_shift = if (.las %in% c(0L, 1L)) 0.5 * (.cex_axis - 1) else 0
+    .ylab_cex_shift = 0.5 * (.cex_lab - 1)
 
     # Detect outer-legend sides (order: bottom, left, top, right).
     .lgnd_pos = settings$legend_args[["x"]]
@@ -1138,7 +1140,7 @@ tinyplot.default = function(
     }
     draw_title(main, sub, xlab, ylab, legend, legend_args, opar,
                xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[1] else 0,
-               ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[2] - .ymgp_shift else 0)
+               ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp[2] - .ymgp_shift - .ylab_cex_shift else 0)
   }
 
 

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -190,6 +190,28 @@ tinytheme = function(
     settings[[n]] = dots[[n]]
   }
 
+  # Compute mgp from spacing primitives when dynmar is active and the user
+  # didn't provide an explicit mgp override. Text is centered on mgp[N], so
+  # it extends 0.5*cex above and below. The visible gap between elements is
+  # controlled by gap.axis (tick tip to tick label edge) and gap.lab (tick
+  # label edge to title edge).
+  if (isTRUE(settings[["dynmar"]]) && !("mgp" %in% names(dots))) {
+    .ga = settings[["gap.axis"]] %||% 0.2
+    .gl = settings[["gap.lab"]] %||% 1.0
+    .ca = settings[["cex.axis"]] %||% 1
+    # FIXME: mgp is shared across sides, so we use the larger label cex to
+    # avoid clipping on either axis. Ideally we'd set side-specific mgp when
+    # cex.xlab and cex.ylab differ.
+    .cl = max(
+      settings[["cex.lab"]] %||% 1,
+      settings[["cex.xlab"]] %||% 0,
+      settings[["cex.ylab"]] %||% 0
+    )
+    .mgp2 = .ga + 0.5 * .ca
+    .mgp1 = .mgp2 + .gl + 0.5 * .cl
+    settings[["mgp"]] = c(.mgp1, .mgp2, 0)
+  }
+
   if (length(settings) > 0) {
     if (theme == "default") {
       # for default theme, we want to revert the original pars and turn off the
@@ -309,6 +331,10 @@ theme_dynamic = modifyList(theme_basic, list(
   ##    `draw_facet_window()` helper builds each side's margin up from this
   ##    pad, adding only what the plot actually needs (tick row, axis label,
   ##    main, sub). See `dynmar_side()` in utils.R.
+  ##  - `mgp` is computed in `tinytheme()` from the spacing primitives
+  ##    (gap.axis, gap.lab) and the active cex.axis/cex.lab values. If the
+  ##    user provides an explicit `mgp`, it is used as-is and the primitives
+  ##    are ignored.
   ##  - `side.sub = 3` moves the sub-caption above the plot (below main).
   ##  - `tcl = -0.3` tightens axis tick marks relative to the base default.
   ##
@@ -316,10 +342,12 @@ theme_dynamic = modifyList(theme_basic, list(
   adj.main = 0,
   adj.sub = 0,
   dynmar = TRUE,
+  gap.axis = 0.2,  # fixed gap (lines) between tick tip and tick label center
+  gap.lab = 1.0,   # gap from tick-label reference to title near cell edge (lines)
   grid = FALSE,
   las = 1,
   mar = c(0.1, 0.1, 0.6, 0.6),
-  mgp = c(3, 1, 0) - c(0.5+0.3, 0.3, 0), # i.e., subtract 0.5 lines + the (abs) value of the tcl adjustment
+  mgp = NULL,      # computed from gap.axis/gap.lab in tinytheme()
   side.sub = 3,
   tcl = -0.3
 ))

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -73,8 +73,32 @@
 #' <some plot>
 #' ```
 #' 
+#' **Spacing primitives.** Dynamic themes compute `mgp` (margin line positions)
+#' automatically from two spacing primitives, rather than requiring users to
+#' reason about how `mar`, `mgp`, and `tcl` combine:
+#'
+#' - `gap.axis`: the gap in margin lines between the tick tip and the near edge
+#'   of the tick label. Default `0.2`.
+#' - `gap.lab`: the gap in margin lines between the far edge of the tick label
+#'   and the near edge of the axis title. Default `1.0`.
+#'
+#' These primitives scale automatically with `cex.axis` and `cex.lab`, so the
+#' visible spacing between elements remains constant regardless of text size.
+#' To adjust spacing, pass them as overrides:
+#'
+#' ```
+#' # Tighter spacing between tick labels and axis titles
+#' tinytheme("clean", gap.lab = 0.5)
+#'
+#' # More room between ticks and tick labels
+#' tinytheme("clean", gap.axis = 0.5)
+#' ```
+#'
+#' If you supply an explicit `mgp` value, it is used as-is and the primitives
+#' are ignored.
+#'
 #' **Caveats.** Known `tinytheme` limitations include:
-#' 
+#'
 #' - Themes do not work well when `legend = "top!"`.
 #'
 #' @return The function returns nothing. It is called for its side effects.
@@ -243,9 +267,12 @@ theme_default = list(
   bty = par("bty"), #"o",
   cex = par("cex"), #1,
   cex.axis = par("cex.axis"), #1,
+  cex.lab = par("cex.lab"), #1,
   cex.main = par("cex.main"), #1.2,
+  cex.sub = par("cex.sub"), #1,
   cex.xlab = NULL, # defer to par("cex.lab") unless set explicitly
   cex.ylab = NULL, # defer to par("cex.lab") unless set explicitly
+  col = par("col"), #"black",
   col.axis = par("col.axis"), #1,
   col.xaxs = par("col.axis"), #1,
   col.yaxs = par("col.axis"), #1,
@@ -278,6 +305,7 @@ theme_default = list(
   pch = par("pch"), # 1,
   side.sub = 1,
   tck = NA,
+  tcl = par("tcl"), # -0.5
   xaxt = "standard",
   yaxt = "standard"
 )

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -115,21 +115,26 @@
 #' p()
 #' 
 #' # Set a theme
-#' tinytheme("bw")
+#' tinytheme("dark")
 #' p()
 #' 
 #' #  A set theme is persistent and will apply to subsequent plots
 #' tinyplot(0:10)
 #'
 #' # Try a different theme
-#' tinytheme("dark")
+#' tinytheme("clean")
 #' p()
 #'          
 #' # Customize the theme by overriding default settings
-#' tinytheme("bw", fg = "green", font.main = 2, font.sub = 3, family = "Palatino")
+#' tinytheme("clean",
+#'           adj.xlab = 1, adj.ylab = 1,
+#'           cex.lab = 0.75, cex.axis = 0.9,
+#'           font.sub = 3,
+#'           gap.axis = 0, gap.lab = 0.5,
+#'           tcl = -0.1)
 #' p()
 #' 
-#' # Another custom theme example
+#' # Another custom theme example, including a different font
 #' tinytheme("bw", font.main = 2, col.axis = "darkcyan", family = "HersheyScript")
 #' p()
 #' 

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -191,10 +191,10 @@ tinytheme = function(
   }
 
   # Compute mgp from spacing primitives when dynmar is active and the user
-  # didn't provide an explicit mgp override. Text is centered on mgp[N], so
-  # it extends 0.5*cex above and below. The visible gap between elements is
-  # controlled by gap.axis (tick tip to tick label edge) and gap.lab (tick
-  # label edge to title edge).
+  # didn't provide an explicit mgp override. The near edge of margin text
+  # (facing the plot region) aligns with the half-cell boundary (0.5*cex from
+  # center). Using 0.5*cex in mgp keeps the visible gap between adjacent text
+  # elements constant regardless of cex scaling.
   if (isTRUE(settings[["dynmar"]]) && !("mgp" %in% names(dots))) {
     .ga = settings[["gap.axis"]] %||% 0.2
     .gl = settings[["gap.lab"]] %||% 1.0
@@ -342,8 +342,8 @@ theme_dynamic = modifyList(theme_basic, list(
   adj.main = 0,
   adj.sub = 0,
   dynmar = TRUE,
-  gap.axis = 0.2,  # fixed gap (lines) between tick tip and tick label center
-  gap.lab = 1.0,   # gap from tick-label reference to title near cell edge (lines)
+  gap.axis = 0.2,  # gap (lines) between tick tip and tick label cell edge
+  gap.lab = 1.0,   # gap (lines) from tick label cell edge to title cell edge
   grid = FALSE,
   las = 1,
   mar = c(0.1, 0.1, 0.6, 0.6),

--- a/R/tpar.R
+++ b/R/tpar.R
@@ -228,6 +228,8 @@ known_tpar = c(
     "col.yaxs",
     "cairo",
     "dynmar",
+    "gap.axis",
+    "gap.lab",
     "facet.bg",
     "facet.border",
     "facet.cex",

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,8 @@ dynmar_side = function(side, label, main = NULL, sub = NULL,
       if (side == 1L) c("cex.xlab", "cex.lab") else c("cex.ylab", "cex.lab"),
       tpar_list = tpars, default = 1
     )
-    label_extent = mgp[1] + (lines - 1) * cex_lab + 0.4 * cex_lab + 0.6
+    descent = if (side == 2L) 0.5 * cex_lab + 0.6 else 0.4 * cex_lab + 0.6
+    label_extent = mgp[1] + (lines - 1) * cex_lab + descent
     # Expressions (e.g., ylab = expression(mm^{1/2})) can be taller than a
     # plain text line due to superscripts, subscripts, fractions, etc. Measure
     # the actual rendered height and add the excess over a normal text line.

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,7 @@ dynmar_side = function(side, label, main = NULL, sub = NULL,
       if (side == 1L) c("cex.xlab", "cex.lab") else c("cex.ylab", "cex.lab"),
       tpar_list = tpars, default = 1
     )
-    descent = if (side == 2L) 0.5 * cex_lab + 0.6 else 0.4 * cex_lab + 0.6
+    descent = if (side == 2L) 0.1 * cex_lab + 1.0 else 0.2 * cex_lab + 0.8
     label_extent = mgp[1] + (lines - 1) * cex_lab + descent
     # Expressions (e.g., ylab = expression(mm^{1/2})) can be taller than a
     # plain text line due to superscripts, subscripts, fractions, etc. Measure

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,11 @@ dynmar_side = function(side, label, main = NULL, sub = NULL,
       if (side == 1L) c("cex.xlab", "cex.lab") else c("cex.ylab", "cex.lab"),
       tpar_list = tpars, default = 1
     )
-    descent = if (side == 2L) 0.1 * cex_lab + 1.0 else 0.2 * cex_lab + 0.8
+    # Side 2: rotated ylab baseline is shifted by ylab_cex_shift, so far edge
+    # = mgp[1] + 0.1*cex_lab + 0.5; descent = 0.1*cex + 0.9 gives constant
+    # 0.4-line buffer (and exactly 1.0 at cex=1, preserving existing behavior).
+    # Side 1: horizontal xlab ink extends ~0.2*cex below center; +0.8 buffer.
+    descent = if (side == 2L) 0.1 * cex_lab + 0.9 else 0.2 * cex_lab + 0.8
     label_extent = mgp[1] + (lines - 1) * cex_lab + descent
     # Expressions (e.g., ylab = expression(mm^{1/2})) can be taller than a
     # plain text line due to superscripts, subscripts, fractions, etc. Measure

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,10 +18,13 @@ text_line_count = function(x) {
 # Compute additive margin "build" for a given side under dynmar.
 # Starts from zero and adds only what the plot actually needs. The tick
 # row and the axis-label row occupy overlapping vertical space (tick row
-# ends at ~|tcl| + mgp[2] + 1, axis label baseline sits at mgp[1]), so the
-# margin is the max of:
-#   - tick-row height (|tcl| + mgp[2] + 1), when the axis is drawn
-#   - axis-label extent (mgp[1] + (N - 1) * cex + 1 line for asc/desc), when present
+# ends at ~|tcl| + mgp[2] + descent, axis label baseline sits at mgp[1]),
+# so the margin is the max of:
+#   - tick-row height (|tcl| + mgp[2] + descent), when the axis is drawn
+#   - axis-label extent (mgp[1] + (N - 1) * cex + descent), when present
+# The descent term = 0.4*cex + 0.6: text at the mgp reference line extends
+# ~0.4*cex lines below baseline (empirically measured character cell descent),
+# plus 0.6 lines fixed buffer for descender characters and spacing.
 # Main/sub sit above/below the plot box on the top/bottom side and add to the
 # margin additively.
 # Tick-label *width* for sides 2/4 (and *height* for 1/3 under las 2:3) is
@@ -33,10 +36,8 @@ dynmar_side = function(side, label, main = NULL, sub = NULL,
   mgp = get_tpar("mgp", tpar_list = tpars)
   tcl = get_tpar("tcl", tpar_list = tpars, default = par("tcl"))
   tick_extent = if (side %in% 1:2 && isTRUE(axis_on)) {
-    # |tcl| = tick mark length (outward); mgp[2] = tick-label distance from
-    # axis; +1 = one line for the tick-label text itself. These mirror base
-    # R's default layout: par(tcl = -0.5, mgp = c(3,1,0)) gives 0.5+1+1=2.5.
-    max(0, -tcl) + mgp[2] + 1
+    cex_axis = get_tpar("cex.axis", tpar_list = tpars, default = 1)
+    max(0, -tcl) + mgp[2] + 0.4 * cex_axis + 0.6
   } else 0
   label_extent = 0
   lines = text_line_count(label)
@@ -45,14 +46,7 @@ dynmar_side = function(side, label, main = NULL, sub = NULL,
       if (side == 1L) c("cex.xlab", "cex.lab") else c("cex.ylab", "cex.lab"),
       tpar_list = tpars, default = 1
     )
-    # Last-line baseline sits at mgp[1] + (N-1)*cex (after line-shift in
-    # draw_title); add a full line to cover ascender+descender so the text
-    # doesn't clip against the device edge.
-    # TODO: the +1 constant doesn't scale with cex_lab, so large values
-    # (e.g. cex.xlab = 3) under-reserve margin and the title overlaps
-    # tick labels. Fixing this requires also pushing the draw-position
-    # (line arg in draw_title) further out. See "P.S." in #574.
-    label_extent = mgp[1] + (lines - 1) * cex_lab + 1
+    label_extent = mgp[1] + (lines - 1) * cex_lab + 0.4 * cex_lab + 0.6
     # Expressions (e.g., ylab = expression(mm^{1/2})) can be taller than a
     # plain text line due to superscripts, subscripts, fractions, etc. Measure
     # the actual rendered height and add the excess over a normal text line.

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.2
 pandoc: 3.9.0.2
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-03-26T21:58:46+0000
+last_built: 2026-05-18T20:00:46+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.2
 pandoc: 3.9.0.2
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-05-18T20:00:46+0000
+last_built: 2026-05-18T20:58:22+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/inst/tinytest/_tinysnapshot/margins_cex_axis1_lab3.svg
+++ b/inst/tinytest/_tinysnapshot/margins_cex_axis1_lab3.svg
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='77.09' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='161.61px' lengthAdjust='spacingAndGlyphs'>cex.axis = 1, cex.lab = 3</text>
+<text x='286.22' y='493.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='240.03px' lengthAdjust='spacingAndGlyphs'>X title (JjQqYy)</text>
+<text transform='translate(30.24,232.70) rotate(-90)' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='239.38px' lengthAdjust='spacingAndGlyphs'>Y title (JjQqYy)</text>
+<line x1='131.31' y1='436.32' x2='441.14' y2='436.32' style='stroke-width: 0.75;' />
+<line x1='131.31' y1='436.32' x2='131.31' y2='440.64' style='stroke-width: 0.75;' />
+<line x1='208.77' y1='436.32' x2='208.77' y2='440.64' style='stroke-width: 0.75;' />
+<line x1='286.22' y1='436.32' x2='286.22' y2='440.64' style='stroke-width: 0.75;' />
+<line x1='363.68' y1='436.32' x2='363.68' y2='440.64' style='stroke-width: 0.75;' />
+<line x1='441.14' y1='436.32' x2='441.14' y2='440.64' style='stroke-width: 0.75;' />
+<text x='131.31' y='457.92' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='208.77' y='457.92' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='286.22' y='457.92' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='363.68' y='457.92' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='441.14' y='457.92' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='77.09' y1='421.24' x2='77.09' y2='44.17' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='421.24' x2='72.77' y2='421.24' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='345.82' x2='72.77' y2='345.82' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='270.41' x2='72.77' y2='270.41' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='195.00' x2='72.77' y2='195.00' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='119.58' x2='72.77' y2='119.58' style='stroke-width: 0.75;' />
+<line x1='77.09' y1='44.17' x2='72.77' y2='44.17' style='stroke-width: 0.75;' />
+<text x='67.01' y='425.37' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='67.01' y='349.95' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1002</text>
+<text x='67.01' y='274.54' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1004</text>
+<text x='67.01' y='199.13' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1006</text>
+<text x='67.01' y='123.71' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1008</text>
+<text x='67.01' y='48.30' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.69px' lengthAdjust='spacingAndGlyphs'>1010</text>
+<polygon points='77.09,436.32 495.36,436.32 495.36,29.09 77.09,29.09 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNzcuMDl8NDk1LjM2fDI5LjA5fDQzNi4zMg=='>
+    <rect x='77.09' y='29.09' width='418.27' height='407.23' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzcuMDl8NDk1LjM2fDI5LjA5fDQzNi4zMg==)'>
+<line x1='131.31' y1='436.32' x2='131.31' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='208.77' y1='436.32' x2='208.77' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='286.22' y1='436.32' x2='286.22' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='363.68' y1='436.32' x2='363.68' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='441.14' y1='436.32' x2='441.14' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='421.24' x2='495.36' y2='421.24' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='345.82' x2='495.36' y2='345.82' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='270.41' x2='495.36' y2='270.41' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='195.00' x2='495.36' y2='195.00' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='119.58' x2='495.36' y2='119.58' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='77.09' y1='44.17' x2='495.36' y2='44.17' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<circle cx='92.58' cy='421.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='131.31' cy='383.53' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='170.04' cy='345.82' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='208.77' cy='308.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='247.49' cy='270.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='286.22' cy='232.70' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='324.95' cy='195.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='363.68' cy='157.29' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='402.41' cy='119.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='441.14' cy='81.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='479.87' cy='44.17' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/margins_cex_axis3_lab1.svg
+++ b/inst/tinytest/_tinysnapshot/margins_cex_axis3_lab1.svg
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='113.18' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='161.61px' lengthAdjust='spacingAndGlyphs'>cex.axis = 3, cex.lab = 1</text>
+<text x='304.27' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='80.00px' lengthAdjust='spacingAndGlyphs'>X title (JjQqYy)</text>
+<text transform='translate(12.96,235.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='79.78px' lengthAdjust='spacingAndGlyphs'>Y title (JjQqYy)</text>
+<line x1='162.72' y1='442.08' x2='445.82' y2='442.08' style='stroke-width: 0.75;' />
+<line x1='162.72' y1='442.08' x2='162.72' y2='446.40' style='stroke-width: 0.75;' />
+<line x1='233.50' y1='442.08' x2='233.50' y2='446.40' style='stroke-width: 0.75;' />
+<line x1='304.27' y1='442.08' x2='304.27' y2='446.40' style='stroke-width: 0.75;' />
+<line x1='375.04' y1='442.08' x2='375.04' y2='446.40' style='stroke-width: 0.75;' />
+<line x1='445.82' y1='442.08' x2='445.82' y2='446.40' style='stroke-width: 0.75;' />
+<text x='162.72' y='478.08' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='233.50' y='478.08' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='304.27' y='478.08' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='375.04' y='478.08' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='445.82' y='478.08' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='40.03px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='113.18' y1='426.78' x2='113.18' y2='44.38' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='426.78' x2='108.86' y2='426.78' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='350.30' x2='108.86' y2='350.30' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='273.82' x2='108.86' y2='273.82' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='197.34' x2='108.86' y2='197.34' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='120.86' x2='108.86' y2='120.86' style='stroke-width: 0.75;' />
+<line x1='113.18' y1='44.38' x2='108.86' y2='44.38' style='stroke-width: 0.75;' />
+<text x='103.10' y='439.17' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='103.10' y='362.69' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1002</text>
+<text x='103.10' y='286.21' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1004</text>
+<text x='103.10' y='209.73' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1006</text>
+<text x='103.10' y='133.25' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1008</text>
+<text x='103.10' y='56.77' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1010</text>
+<polygon points='113.18,442.08 495.36,442.08 495.36,29.09 113.18,29.09 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMTEzLjE4fDQ5NS4zNnwyOS4wOXw0NDIuMDg='>
+    <rect x='113.18' y='29.09' width='382.18' height='412.99' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTEzLjE4fDQ5NS4zNnwyOS4wOXw0NDIuMDg=)'>
+<line x1='162.72' y1='442.08' x2='162.72' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='233.50' y1='442.08' x2='233.50' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='304.27' y1='442.08' x2='304.27' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='375.04' y1='442.08' x2='375.04' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='445.82' y1='442.08' x2='445.82' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='426.78' x2='495.36' y2='426.78' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='350.30' x2='495.36' y2='350.30' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='273.82' x2='495.36' y2='273.82' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='197.34' x2='495.36' y2='197.34' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='120.86' x2='495.36' y2='120.86' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='113.18' y1='44.38' x2='495.36' y2='44.38' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<circle cx='127.34' cy='426.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='162.72' cy='388.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='198.11' cy='350.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='233.50' cy='312.06' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='268.88' cy='273.82' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='304.27' cy='235.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='339.66' cy='197.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='375.04' cy='159.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='410.43' cy='120.86' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='445.82' cy='82.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='481.21' cy='44.38' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/margins_cex_axis3_lab3.svg
+++ b/inst/tinytest/_tinysnapshot/margins_cex_axis3_lab3.svg
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='130.46' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='161.61px' lengthAdjust='spacingAndGlyphs'>cex.axis = 3, cex.lab = 3</text>
+<text x='312.91' y='493.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='240.03px' lengthAdjust='spacingAndGlyphs'>X title (JjQqYy)</text>
+<text transform='translate(30.24,225.50) rotate(-90)' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='239.38px' lengthAdjust='spacingAndGlyphs'>Y title (JjQqYy)</text>
+<line x1='177.76' y1='421.92' x2='448.06' y2='421.92' style='stroke-width: 0.75;' />
+<line x1='177.76' y1='421.92' x2='177.76' y2='426.24' style='stroke-width: 0.75;' />
+<line x1='245.34' y1='421.92' x2='245.34' y2='426.24' style='stroke-width: 0.75;' />
+<line x1='312.91' y1='421.92' x2='312.91' y2='426.24' style='stroke-width: 0.75;' />
+<line x1='380.48' y1='421.92' x2='380.48' y2='426.24' style='stroke-width: 0.75;' />
+<line x1='448.06' y1='421.92' x2='448.06' y2='426.24' style='stroke-width: 0.75;' />
+<text x='177.76' y='457.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='245.34' y='457.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='312.91' y='457.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='380.48' y='457.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='448.06' y='457.92' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='40.03px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='130.46' y1='407.37' x2='130.46' y2='43.64' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='407.37' x2='126.14' y2='407.37' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='334.62' x2='126.14' y2='334.62' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='261.88' x2='126.14' y2='261.88' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='189.13' x2='126.14' y2='189.13' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='116.38' x2='126.14' y2='116.38' style='stroke-width: 0.75;' />
+<line x1='130.46' y1='43.64' x2='126.14' y2='43.64' style='stroke-width: 0.75;' />
+<text x='120.38' y='419.75' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='120.38' y='347.01' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1002</text>
+<text x='120.38' y='274.26' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1004</text>
+<text x='120.38' y='201.51' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1006</text>
+<text x='120.38' y='128.77' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1008</text>
+<text x='120.38' y='56.02' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1010</text>
+<polygon points='130.46,421.92 495.36,421.92 495.36,29.09 130.46,29.09 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMTMwLjQ2fDQ5NS4zNnwyOS4wOXw0MjEuOTI='>
+    <rect x='130.46' y='29.09' width='364.90' height='392.83' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTMwLjQ2fDQ5NS4zNnwyOS4wOXw0MjEuOTI=)'>
+<line x1='177.76' y1='421.92' x2='177.76' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='245.34' y1='421.92' x2='245.34' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='312.91' y1='421.92' x2='312.91' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='380.48' y1='421.92' x2='380.48' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='448.06' y1='421.92' x2='448.06' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='407.37' x2='495.36' y2='407.37' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='334.62' x2='495.36' y2='334.62' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='261.88' x2='495.36' y2='261.88' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='189.13' x2='495.36' y2='189.13' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='116.38' x2='495.36' y2='116.38' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='130.46' y1='43.64' x2='495.36' y2='43.64' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<circle cx='143.98' cy='407.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='177.76' cy='371.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='211.55' cy='334.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='245.34' cy='298.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='279.12' cy='261.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='312.91' cy='225.50' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='346.70' cy='189.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='380.48' cy='152.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='414.27' cy='116.38' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='448.06' cy='80.01' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='481.85' cy='43.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/margins_large_cex.svg
+++ b/inst/tinytest/_tinysnapshot/margins_large_cex.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='121.82' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='145.61px' lengthAdjust='spacingAndGlyphs'>cex.axis=3, cex.lab=2</text>
+<text x='308.59' y='496.80' text-anchor='middle' style='font-size: 24.00px; font-family: "Liberation Sans";' textLength='73.38px' lengthAdjust='spacingAndGlyphs'>X label</text>
+<text transform='translate(21.60,230.54) rotate(-90)' text-anchor='middle' style='font-size: 24.00px; font-family: "Liberation Sans";' textLength='72.94px' lengthAdjust='spacingAndGlyphs'>Y label</text>
+<line x1='170.24' y1='432.00' x2='446.94' y2='432.00' style='stroke-width: 0.75;' />
+<line x1='170.24' y1='432.00' x2='170.24' y2='436.32' style='stroke-width: 0.75;' />
+<line x1='239.42' y1='432.00' x2='239.42' y2='436.32' style='stroke-width: 0.75;' />
+<line x1='308.59' y1='432.00' x2='308.59' y2='436.32' style='stroke-width: 0.75;' />
+<line x1='377.76' y1='432.00' x2='377.76' y2='436.32' style='stroke-width: 0.75;' />
+<line x1='446.94' y1='432.00' x2='446.94' y2='436.32' style='stroke-width: 0.75;' />
+<text x='170.24' y='468.00' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='239.42' y='468.00' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='308.59' y='468.00' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='377.76' y='468.00' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='446.94' y='468.00' text-anchor='middle' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='40.03px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='121.82' y1='417.08' x2='121.82' y2='44.01' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='417.08' x2='117.50' y2='417.08' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='342.46' x2='117.50' y2='342.46' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='267.85' x2='117.50' y2='267.85' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='193.24' x2='117.50' y2='193.24' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='118.62' x2='117.50' y2='118.62' style='stroke-width: 0.75;' />
+<line x1='121.82' y1='44.01' x2='117.50' y2='44.01' style='stroke-width: 0.75;' />
+<text x='111.74' y='429.46' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='111.74' y='354.85' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1002</text>
+<text x='111.74' y='280.23' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1004</text>
+<text x='111.74' y='205.62' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1006</text>
+<text x='111.74' y='131.01' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1008</text>
+<text x='111.74' y='56.39' text-anchor='end' style='font-size: 36.00px; font-family: "Liberation Sans";' textLength='80.06px' lengthAdjust='spacingAndGlyphs'>1010</text>
+<polygon points='121.82,432.00 495.36,432.00 495.36,29.09 121.82,29.09 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMTIxLjgyfDQ5NS4zNnwyOS4wOXw0MzIuMDA='>
+    <rect x='121.82' y='29.09' width='373.54' height='402.91' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTIxLjgyfDQ5NS4zNnwyOS4wOXw0MzIuMDA=)'>
+<line x1='170.24' y1='432.00' x2='170.24' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='239.42' y1='432.00' x2='239.42' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='308.59' y1='432.00' x2='308.59' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='377.76' y1='432.00' x2='377.76' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='446.94' y1='432.00' x2='446.94' y2='29.09' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='417.08' x2='495.36' y2='417.08' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='342.46' x2='495.36' y2='342.46' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='267.85' x2='495.36' y2='267.85' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='193.24' x2='495.36' y2='193.24' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='118.62' x2='495.36' y2='118.62' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='121.82' y1='44.01' x2='495.36' y2='44.01' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<circle cx='135.66' cy='417.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='170.24' cy='379.77' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='204.83' cy='342.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='239.42' cy='305.16' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='274.00' cy='267.85' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='308.59' cy='230.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='343.18' cy='193.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='377.76' cy='155.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='412.35' cy='118.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='446.94' cy='81.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='481.53' cy='44.01' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/margins_large_cex_facets.svg
+++ b/inst/tinytest/_tinysnapshot/margins_large_cex_facets.svg
@@ -1,0 +1,221 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<circle cx='480.15' cy='248.40' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='480.15' cy='262.80' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='480.15' cy='277.20' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<text x='482.13' y='234.00' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='490.95' y='252.53' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='490.95' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='490.95' y='281.33' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0NTQuOTV8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='454.95' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0NTQuOTV8MC4wMHw1MDQuMDA=)'>
+<text x='257.45' y='498.24' text-anchor='middle' style='font-size: 18.00px; font-family: "Liberation Sans";' textLength='55.70px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text transform='translate(17.28,226.44) rotate(-90)' text-anchor='middle' style='font-size: 18.00px; font-family: "Liberation Sans";' textLength='126.11px' lengthAdjust='spacingAndGlyphs'>Miles per gallon</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuOTV8MTY5Ljg5fDI0LjQ4fDQ0NC4yNA=='>
+    <rect x='59.95' y='24.48' width='109.94' height='419.76' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuOTV8MTY5Ljg5fDI0LjQ4fDQ0NC4yNA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='76.70' y1='444.24' x2='154.78' y2='444.24' style='stroke-width: 0.75;' />
+<line x1='76.70' y1='444.24' x2='76.70' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='102.73' y1='444.24' x2='102.73' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='128.75' y1='444.24' x2='128.75' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='154.78' y1='444.24' x2='154.78' y2='447.09' style='stroke-width: 0.75;' />
+<text x='76.70' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='102.73' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='128.75' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='154.78' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.95' y1='435.31' x2='59.95' y2='104.53' style='stroke-width: 0.75;' />
+<line x1='59.95' y1='435.31' x2='57.10' y2='435.31' style='stroke-width: 0.75;' />
+<line x1='59.95' y1='352.61' x2='57.10' y2='352.61' style='stroke-width: 0.75;' />
+<line x1='59.95' y1='269.92' x2='57.10' y2='269.92' style='stroke-width: 0.75;' />
+<line x1='59.95' y1='187.22' x2='57.10' y2='187.22' style='stroke-width: 0.75;' />
+<line x1='59.95' y1='104.53' x2='57.10' y2='104.53' style='stroke-width: 0.75;' />
+<text x='53.30' y='440.76' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='53.30' y='358.06' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='53.30' y='275.37' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='53.30' y='192.67' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='53.30' y='109.98' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>30</text>
+<rect x='59.95' y='8.64' width='109.94' height='15.84' style='stroke-width: 0.75; fill: #E5E5E5;' />
+<text x='114.92' y='20.69' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polygon points='59.95,444.24 169.89,444.24 169.89,24.48 59.95,24.48 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpNTkuOTV8MTY5Ljg5fDI0LjQ4fDQ0NC4yNA==)'>
+<line x1='76.70' y1='444.24' x2='76.70' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='102.73' y1='444.24' x2='102.73' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='128.75' y1='444.24' x2='128.75' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='154.78' y1='444.24' x2='154.78' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='59.95' y1='435.31' x2='169.89' y2='435.31' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='59.95' y1='352.61' x2='169.89' y2='352.61' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='59.95' y1='269.92' x2='169.89' y2='269.92' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='59.95' y1='187.22' x2='169.89' y2='187.22' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='59.95' y1='104.53' x2='169.89' y2='104.53' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+</g>
+<defs>
+  <clipPath id='cpMjAyLjQ4fDMxMi40MnwyNC40OHw0NDQuMjQ='>
+    <rect x='202.48' y='24.48' width='109.94' height='419.76' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjAyLjQ4fDMxMi40MnwyNC40OHw0NDQuMjQ=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='219.23' y1='444.24' x2='297.31' y2='444.24' style='stroke-width: 0.75;' />
+<line x1='219.23' y1='444.24' x2='219.23' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='245.26' y1='444.24' x2='245.26' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='271.29' y1='444.24' x2='271.29' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='297.31' y1='444.24' x2='297.31' y2='447.09' style='stroke-width: 0.75;' />
+<text x='219.23' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='245.26' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='271.29' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='297.31' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='202.48' y1='435.31' x2='202.48' y2='104.53' style='stroke-width: 0.75;' />
+<line x1='202.48' y1='435.31' x2='199.63' y2='435.31' style='stroke-width: 0.75;' />
+<line x1='202.48' y1='352.61' x2='199.63' y2='352.61' style='stroke-width: 0.75;' />
+<line x1='202.48' y1='269.92' x2='199.63' y2='269.92' style='stroke-width: 0.75;' />
+<line x1='202.48' y1='187.22' x2='199.63' y2='187.22' style='stroke-width: 0.75;' />
+<line x1='202.48' y1='104.53' x2='199.63' y2='104.53' style='stroke-width: 0.75;' />
+<text x='195.83' y='440.76' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='195.83' y='358.06' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='195.83' y='275.37' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='195.83' y='192.67' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='195.83' y='109.98' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>30</text>
+<rect x='202.48' y='8.64' width='109.94' height='15.84' style='stroke-width: 0.75; fill: #E5E5E5;' />
+<text x='257.45' y='20.69' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<polygon points='202.48,444.24 312.42,444.24 312.42,24.48 202.48,24.48 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMjAyLjQ4fDMxMi40MnwyNC40OHw0NDQuMjQ=)'>
+<line x1='219.23' y1='444.24' x2='219.23' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='245.26' y1='444.24' x2='245.26' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='271.29' y1='444.24' x2='271.29' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='297.31' y1='444.24' x2='297.31' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='202.48' y1='435.31' x2='312.42' y2='435.31' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='202.48' y1='352.61' x2='312.42' y2='352.61' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='202.48' y1='269.92' x2='312.42' y2='269.92' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='202.48' y1='187.22' x2='312.42' y2='187.22' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='202.48' y1='104.53' x2='312.42' y2='104.53' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+</g>
+<defs>
+  <clipPath id='cpMzQ1LjAxfDQ1NC45NXwyNC40OHw0NDQuMjQ='>
+    <rect x='345.01' y='24.48' width='109.94' height='419.76' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzQ1LjAxfDQ1NC45NXwyNC40OHw0NDQuMjQ=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='361.76' y1='444.24' x2='439.84' y2='444.24' style='stroke-width: 0.75;' />
+<line x1='361.76' y1='444.24' x2='361.76' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='387.79' y1='444.24' x2='387.79' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='413.82' y1='444.24' x2='413.82' y2='447.09' style='stroke-width: 0.75;' />
+<line x1='439.84' y1='444.24' x2='439.84' y2='447.09' style='stroke-width: 0.75;' />
+<text x='361.76' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='387.79' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='413.82' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='439.84' y='463.25' text-anchor='middle' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='345.01' y1='435.31' x2='345.01' y2='104.53' style='stroke-width: 0.75;' />
+<line x1='345.01' y1='435.31' x2='342.16' y2='435.31' style='stroke-width: 0.75;' />
+<line x1='345.01' y1='352.61' x2='342.16' y2='352.61' style='stroke-width: 0.75;' />
+<line x1='345.01' y1='269.92' x2='342.16' y2='269.92' style='stroke-width: 0.75;' />
+<line x1='345.01' y1='187.22' x2='342.16' y2='187.22' style='stroke-width: 0.75;' />
+<line x1='345.01' y1='104.53' x2='342.16' y2='104.53' style='stroke-width: 0.75;' />
+<text x='338.36' y='440.76' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='338.36' y='358.06' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='338.36' y='275.37' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='338.36' y='192.67' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='338.36' y='109.98' text-anchor='end' style='font-size: 15.84px; font-family: "Liberation Sans";' textLength='17.59px' lengthAdjust='spacingAndGlyphs'>30</text>
+<rect x='345.01' y='8.64' width='109.94' height='15.84' style='stroke-width: 0.75; fill: #E5E5E5;' />
+<text x='399.98' y='20.69' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polygon points='345.01,444.24 454.95,444.24 454.95,24.48 345.01,24.48 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMzQ1LjAxfDQ1NC45NXwyNC40OHw0NDQuMjQ=)'>
+<line x1='361.76' y1='444.24' x2='361.76' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='387.79' y1='444.24' x2='387.79' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='413.82' y1='444.24' x2='413.82' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='439.84' y1='444.24' x2='439.84' y2='24.48' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='345.01' y1='435.31' x2='454.95' y2='435.31' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='345.01' y1='352.61' x2='454.95' y2='352.61' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='345.01' y1='269.92' x2='454.95' y2='269.92' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='345.01' y1='187.22' x2='454.95' y2='187.22' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+<line x1='345.01' y1='104.53' x2='454.95' y2='104.53' style='stroke-width: 0.75; stroke: #D3D3D3; stroke-dasharray: 1.00,3.00;' />
+</g>
+<g clip-path='url(#cpNTkuOTV8MTY5Ljg5fDI0LjQ4fDQ0NC4yNA==)'>
+<circle cx='85.03' cy='223.61' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='107.67' cy='197.15' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='106.63' cy='223.61' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='81.90' cy='64.84' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='66.68' cy='97.91' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='72.40' cy='40.03' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='88.80' cy='245.11' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='75.01' cy='149.18' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='80.34' cy='170.68' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='64.02' cy='97.91' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+<circle cx='97.00' cy='246.76' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #4E79A7;' />
+</g>
+<g clip-path='url(#cpMjAyLjQ4fDMxMi40MnwyNC40OHw0NDQuMjQ=)'>
+<circle cx='235.37' cy='253.38' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='242.00' cy='253.38' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='250.85' cy='246.76' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='257.23' cy='301.34' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='256.71' cy='283.15' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='256.71' cy='306.30' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+<circle cx='239.27' cy='274.88' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #F28E2B;' />
+</g>
+<g clip-path='url(#cpMzQ1LjAxfDQ1NC45NXwyNC40OHw0NDQuMjQ=)'>
+<circle cx='399.24' cy='291.42' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='402.62' cy='364.19' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='415.64' cy='329.46' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='406.79' cy='314.57' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='408.09' cy='349.31' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='446.35' cy='428.69' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='450.88' cy='428.69' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='448.82' cy='357.58' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='401.32' cy='344.34' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='399.11' cy='349.31' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='409.65' cy='380.73' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='409.78' cy='283.15' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='392.21' cy='339.38' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+<circle cx='402.62' cy='352.61' r='1.78' style='stroke-width: 0.75; stroke: none; fill: #E15759;' />
+</g>
+<defs>
+  <clipPath id='cpMTE5LjA0fDQxNy45OXw1OS4wNHwzNTguNTY='>
+    <rect x='119.04' y='59.04' width='298.95' height='299.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTE5LjA0fDQxNy45OXw1OS4wNHwzNTguNTY=)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/tinytheme_ephemeral.svg
+++ b/inst/tinytest/_tinysnapshot/tinytheme_ephemeral.svg
@@ -269,13 +269,13 @@
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
 <line x1='317.07' y1='430.56' x2='470.29' y2='430.56' style='stroke-width: 0.75;' />
-<line x1='317.07' y1='430.56' x2='317.07' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='342.60' y1='430.56' x2='342.60' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='368.14' y1='430.56' x2='368.14' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='393.68' y1='430.56' x2='393.68' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='419.21' y1='430.56' x2='419.21' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='444.75' y1='430.56' x2='444.75' y2='434.88' style='stroke-width: 0.75;' />
-<line x1='470.29' y1='430.56' x2='470.29' y2='434.88' style='stroke-width: 0.75;' />
+<line x1='317.07' y1='430.56' x2='317.07' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='342.60' y1='430.56' x2='342.60' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='368.14' y1='430.56' x2='368.14' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='393.68' y1='430.56' x2='393.68' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='419.21' y1='430.56' x2='419.21' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='444.75' y1='430.56' x2='444.75' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='470.29' y1='430.56' x2='470.29' y2='437.76' style='stroke-width: 0.75;' />
 <text x='317.07' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='342.60' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
 <text x='368.14' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
@@ -284,14 +284,14 @@
 <text x='444.75' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
 <text x='470.29' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
 <line x1='311.04' y1='397.69' x2='311.04' y2='63.24' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='397.69' x2='306.72' y2='397.69' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='349.91' x2='306.72' y2='349.91' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='302.13' x2='306.72' y2='302.13' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='254.36' x2='306.72' y2='254.36' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='206.58' x2='306.72' y2='206.58' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='158.80' x2='306.72' y2='158.80' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='111.02' x2='306.72' y2='111.02' style='stroke-width: 0.75;' />
-<line x1='311.04' y1='63.24' x2='306.72' y2='63.24' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='397.69' x2='303.84' y2='397.69' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='349.91' x2='303.84' y2='349.91' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='302.13' x2='303.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='254.36' x2='303.84' y2='254.36' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='206.58' x2='303.84' y2='206.58' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='158.80' x2='303.84' y2='158.80' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='111.02' x2='303.84' y2='111.02' style='stroke-width: 0.75;' />
+<line x1='311.04' y1='63.24' x2='303.84' y2='63.24' style='stroke-width: 0.75;' />
 <text transform='translate(293.76,397.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
 <text transform='translate(293.76,349.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
 <text transform='translate(293.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>

--- a/inst/tinytest/test-margins.R
+++ b/inst/tinytest/test-margins.R
@@ -118,3 +118,62 @@ expect_true(
 #     theme = "clean")
 # }
 # expect_snapshot_plot(f, label = "margins_math_expression")
+
+# Dynamic margin and mgp scaling with large cex values (#574)
+
+# Helper: capture mar and mgp from inside the plot
+get_plot_pars = function(...) {
+  tinyplot(...)
+  list(mar = par("mar"), mgp = par("mgp"))
+}
+
+# At default cex=1, mgp is unchanged from the theme value
+expect_equal(
+  {
+    tinytheme("clean")
+    p = get_plot_pars(1:10, 1:10, xlab = "X", ylab = "Y")
+    tinytheme()
+    p$mgp
+  },
+  c(2.2, 0.7, 0),
+  info = "dynmar_mgp_unchanged_at_cex_1"
+)
+
+# cex.axis=3, cex.lab=2: mgp scales to accommodate larger text
+expect_equal(
+  {
+    tinytheme("clean", cex.axis = 3, cex.lab = 2)
+    p = get_plot_pars(1:10, 1:10, xlab = "X", ylab = "Y")
+    tinytheme()
+    p$mgp
+  },
+  c(3.7, 1.7, 0),
+  info = "dynmar_mgp_at_cex_axis_3_cex_lab_2"
+)
+
+# cex.axis=0.5, cex.lab=0.5: mgp shrinks for small text
+expect_equal(
+  {
+    tinytheme("clean", cex.axis = 0.5, cex.lab = 0.5)
+    p = get_plot_pars(1:10, 1:10, xlab = "X", ylab = "Y")
+    tinytheme()
+    p$mgp
+  },
+  c(1.7, 0.45, 0),
+  info = "dynmar_mgp_shrinks_at_small_cex"
+)
+
+# Snapshot tests for scaled-cex margins
+f = function() {
+  tinytheme("clean", cex.axis = 3, cex.lab = 2)
+  tinyplot(1000:1010, xlab = "X label", ylab = "Y label", main = "cex.axis=3, cex.lab=2")
+  tinytheme()
+}
+expect_snapshot_plot(f, label = "margins_large_cex")
+
+f = function() {
+  tinytheme("clean", cex.axis = 2, cex.lab = 1.5)
+  tinyplot(mpg ~ wt | cyl, facet = "by", data = mtcars, xlab = "Weight", ylab = "Miles per gallon")
+  tinytheme()
+}
+expect_snapshot_plot(f, label = "margins_large_cex_facets")

--- a/inst/tinytest/test-margins.R
+++ b/inst/tinytest/test-margins.R
@@ -177,3 +177,31 @@ f = function() {
   tinytheme()
 }
 expect_snapshot_plot(f, label = "margins_large_cex_facets")
+
+# Varying cex.axis vs cex.lab independently to check gap constancy
+f = function() {
+  tinytheme("clean", cex.axis = 3, cex.lab = 1)
+  tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
+           main = "cex.axis = 3, cex.lab = 1")
+  box("inner", lty = 2)
+  tinytheme()
+}
+expect_snapshot_plot(f, label = "margins_cex_axis3_lab1")
+
+f = function() {
+  tinytheme("clean", cex.axis = 1, cex.lab = 3)
+  tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
+           main = "cex.axis = 1, cex.lab = 3")
+  box("inner", lty = 2)
+  tinytheme()
+}
+expect_snapshot_plot(f, label = "margins_cex_axis1_lab3")
+
+f = function() {
+  tinytheme("clean", cex.axis = 3, cex.lab = 3)
+  tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
+           main = "cex.axis = 3, cex.lab = 3")
+  box("inner", lty = 2)
+  tinytheme()
+}
+expect_snapshot_plot(f, label = "margins_cex_axis3_lab3")

--- a/man/tinytheme.Rd
+++ b/man/tinytheme.Rd
@@ -86,6 +86,30 @@ tpar(mar = c(5, 5, 2, 2))
 <some plot>
 }\if{html}{\out{</div>}}
 
+\strong{Spacing primitives.} Dynamic themes compute \code{mgp} (margin line positions)
+automatically from two spacing primitives, rather than requiring users to
+reason about how \code{mar}, \code{mgp}, and \code{tcl} combine:
+\itemize{
+\item \code{gap.axis}: the gap in margin lines between the tick tip and the near edge
+of the tick label. Default \code{0.2}.
+\item \code{gap.lab}: the gap in margin lines between the far edge of the tick label
+and the near edge of the axis title. Default \code{1.0}.
+}
+
+These primitives scale automatically with \code{cex.axis} and \code{cex.lab}, so the
+visible spacing between elements remains constant regardless of text size.
+To adjust spacing, pass them as overrides:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{# Tighter spacing between tick labels and axis titles
+tinytheme("clean", gap.lab = 0.5)
+
+# More room between ticks and tick labels
+tinytheme("clean", gap.axis = 0.5)
+}\if{html}{\out{</div>}}
+
+If you supply an explicit \code{mgp} value, it is used as-is and the primitives
+are ignored.
+
 \strong{Caveats.} Known \code{tinytheme} limitations include:
 \itemize{
 \item Themes do not work well when \code{legend = "top!"}.

--- a/vignettes/themes.qmd
+++ b/vignettes/themes.qmd
@@ -83,12 +83,12 @@ tinytheme()
 tinyplot(mpg ~ hp, data = mtcars, main = "Fuel efficiency vs. horsepower")
 ```
 
-### Aside: ephemeral themes
+### Persistent versus ephemeral themes
 
-We expect that users will generally want to set a persistent theme for all
-(most) of their plots. But it is also possible to set a ephemeral theme for a
-particular plot by calling the `tinyplot(..., theme = <theme>)` argument
-directly.
+Setting a persistent theme for all of your plots is often convenient. But there
+are also times where you might prefer an ephemeral theme that only applies to a
+single plot (plus any added layers). You can invoke such an ephemeral theme by
+calling the `tinyplot(..., theme = <theme>)` argument directly.
 
 ```{r}
 #| layout-ncol: 2
@@ -96,7 +96,11 @@ tinyplot(mpg ~ hp, data = mtcars, main = "Ephemeral theme", theme = "clean")
 tinyplot(mpg ~ hp, data = mtcars, main = "Back to the default")
 ```
 
-
+One of the advantages of ephemeral themes is that they won't interfere with any
+other base graphics calls (e.g, `plot`, `coplot`, etc.) In contrast, the 
+persistent hook mechanism of `tinytheme()` will also intercept these other base
+plot calls, which may lead to undesirable outcomes unless you reset to the
+default behaviour.
 
 ### Gallery
 
@@ -104,14 +108,16 @@ We'll use the following running example to demonstrate the full gallery of
 built-in `tinytheme()` themes.
 
 ```{r}
-p = function() {
+p = function(theme = "default") {
   tinyplot(
     Sepal.Width ~ Sepal.Length | Species,
     facet = "by",
     data = iris,
-    main = "Title of the plot",
-    sub = "A smaller subtitle"
+    main = paste0('theme = "', theme, '"'),
+    sub = "subtitle",
+    theme = theme
   )
+  box("outer", lty = 2)
 }
 ```
 
@@ -134,84 +140,21 @@ p = function() {
 <!-- tinytheme() -->
 <!-- ``` -->
 
-#### "default"
 
 ```{r}
-tinytheme() ## same as tinytheme("default")
-p()
+p() ## same as "default"
+p("basic")
+p("dynamic")
+p("clean")
+p("clean2")
+p("classic")
+p("bw")
+p("minimal")
+p("ipsum")
+p("dark")
+p("tufte")
+p("void")
 ```
-
-#### "basic"
-
-```{r}
-tinytheme("basic")
-p()
-```
-
-#### "clean"
-
-```{r}
-tinytheme("clean")
-p()
-```
-
-#### "clean2"
-
-```{r}
-tinytheme("clean2")
-p()
-```
-
-#### "classic"
-
-```{r}
-tinytheme("classic")
-p()
-```
-
-#### "bw"
-
-```{r}
-tinytheme("bw")
-p()
-```
-
-#### "minimal"
-
-```{r}
-tinytheme("minimal")
-p()
-```
-
-#### "ipsum"
-
-```{r}
-tinytheme("ipsum")
-p()
-```
-
-#### "dark"
-
-```{r}
-tinytheme("dark")
-p()
-```
-
-#### "tufte"
-
-```{r}
-tinytheme("tufte")
-p()
-```
-
-#### "void"
-
-```{r}
-tinytheme("void")
-p()
-```
-
-#### "ridge"
 
 ::: {.callout-note}
 The specialized `"ridge"` and `"ridge2"` themes are only intended for use with
@@ -219,30 +162,20 @@ ridge plot types.
 :::
 
 ```{r}
-p2 = function() {
+p2 = function(theme = "ridge") {
   tinyplot(
     Species ~ Sepal.Width | Species, legend = FALSE,
     data = iris,
     type = "ridge",
-    main = "Title of the plot",
-    sub = "A smaller subtitle"
+    main = paste0('theme = "', theme, '"'),
+    sub = "subtitle",
+    theme = theme
   )
+  box("outer", lty = 2)
 }
 
-tinytheme("ridge")
-p2()
-```
-
-#### "ridge2"
-
-```{r}
-tinytheme("ridge2")
-p2()
-```
-
-```{r}
-# Reset to default theme
-tinytheme()
+p2("ridge")
+p2("ridge2")
 ```
 
 Please feel free to make suggestions about themes, or contribute new themes by
@@ -291,18 +224,37 @@ It plays very nicely with **tinyplot**.
 
 :::
 
-Similarly, to create your own themes "from scratch", set the theme to
-`"default"` and pass additional graphical parameters to `tinytheme()`.
+#### Spacing primitives
+
+One feature of the `tinytheme()` infrastructure that is especially relevant
+to customized themes is how dynamic spacing works. Dynamic themes in
+**tinyplot** automatically compute margin positions (`mar`, `mgp`) so that axis
+and text elements are well-spaced. Moreover, rather than requiring you to
+manually reason about how `mar`, `mgp`, and `tcl` combine to produce certain
+spacing, which---trust us---is both confusing and error prone, you can control
+the gaps between elements directly through two spacing "primitives":
+
+- `gap.axis`: the gap (in margin lines) between the tick tip and the near edge
+  of the tick label. Default `0.2`.
+- `gap.lab`: the gap (in margin lines) between the far edge of the tick label
+  and the near edge of the axis title. Default `1.0`.
+
+These scale automatically with companion features like `cex.axis` and `cex.lab`,
+maintaining constant visible spacing regardless of text size. For example:
 
 ```{r}
-tinytheme("default", font.main = 3, col = "red")
-p()
+#| layout-ncol: 2
+tinytheme("dynamic", gap.axis = 0, gap.lab = 0.5)
+tinyplot(mpg ~ hp, data = mtcars, main = "Tighter gaps")
+
+tinytheme("dynamic", gap.axis = 2, gap.lab = 2)
+tinyplot(mpg ~ hp, data = mtcars, main = "Looser gaps")
+tinytheme() # reset
 ```
 
-```{r}
-# Reset to default theme
-tinytheme()
-```
+Again, this is much more convenient that fiddling with `mgp` values. But you can
+always provide `mgp` values if you wish; in which it will take precedence and
+the primitives are ignored.
 
 ::: {.callout-tip}
 To see the full list of parameters that defines a particular theme, simply

--- a/vignettes/themes.qmd
+++ b/vignettes/themes.qmd
@@ -21,12 +21,14 @@ knitr::opts_chunk$set(
 ```
 
 The base R aesthetic tends to divide option. Some people like the
-default minimalist look of base R plots and/or are happy to customize the (many)
+default minimalist look of base R plots and are happy to customize the (many)
 graphical parameters that are available to them. Others find base plots ugly
-and don't want to spend time endlessly tweaking different parameters. Moreover,
-the inherent "canvas" approach to drawing base R graphics, with fixed placement
-for plot elements, means that plots don't adjust dynamically and this can lead
-to awkward whitespace artifacts unless the user explicitly accounts for them.
+and don't want to spend time endlessly tweaking different parameters. Meanwhile,
+the "canvas" drawing system of base R graphics creates its own set of issues. 
+Each plot element is drawn according to a fixed placement logic, which means 
+that the overall composition can't adjust dynamically according to the elements
+that are present or not (including titles). This can lead to awkward whitespace
+artifacts unless the user explicitly accounts for them.
 
 Regardless of where you stand in this debate, the **tinyplot** view is that base
 R graphics should ideally combine flexibility and ease of use with aesthetically
@@ -56,7 +58,8 @@ tinyplot(
 
 One particular feature that may interest users is the fact that `tinytheme()`
 uses some internal ~~magic~~ logic to dynamically adjust plot margins to avoid
-whitespace. For example, when long horizontal y-axis labels are detected:
+whitespace and overlapping elements. For example, notice how the plot region 
+here bumps out to accomodate the long horizontal y-axis labels:
 
 ```{r}
 tinyplot(
@@ -105,7 +108,7 @@ default behaviour.
 ### Gallery
 
 We'll use the following running example to demonstrate the full gallery of
-built-in `tinytheme()` themes.
+built-in **tinyplot** themes.
 
 ```{r}
 p = function(theme = "default") {
@@ -223,8 +226,6 @@ catalog, either on-the-fly or downloaded to your permanent fontbook collection.
 It plays very nicely with **tinyplot**.
 
 :::
-
-#### Spacing primitives
 
 One feature of the `tinytheme()` infrastructure that is especially relevant
 to customized themes is how dynamic spacing works. Dynamic themes in


### PR DESCRIPTION
Closes #590

This was much trickier to fix than I initially expected. I went down multiple manual debugging rabbit holes and dead ends, as well as numerous Claude sessions. (See "Gory Details" below.) But I think we've arrived at a robust framework and logic that yields principled + consistent outcomes.

### MWE

The proof is in the pudding, so some examples first:

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
tinytheme("clean", cex.axis = 3, cex.lab = 1)
tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
         main = "cex.axis = 3, cex.lab = 1")
box("inner", lty = 2)
```

![](https://i.imgur.com/uMHT5up.png)<!-- -->

``` r
tinytheme()
tinytheme("clean", cex.axis = 1, cex.lab = 3)
tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
         main = "cex.axis = 1, cex.lab = 3")
box("inner", lty = 2)
```

![](https://i.imgur.com/ejyERZi.png)<!-- -->

``` r
tinytheme()
tinytheme("clean", cex.axis = 3, cex.lab = 3)
tinyplot(1000:1010, xlab = "X title (JjQqYy)", ylab = "Y title (JjQqYy)",
         main = "cex.axis = 3, cex.lab = 3")
box("inner", lty = 2)
```

![](https://i.imgur.com/jLOLmiV.png)<!-- -->

### How it works

The key architectural change: `mgp` is now intercepted and **adjusted per-side at draw time**, applying differential correction logic appropriate to each axis.

R's `par("mgp")` is a single global value. But sides 1 and 2 (axes "x" and "y") have fundamentally different text-positioning models. Horizontal text (x-axis) is cell-centered on the specified margin line, whereas rotated text (y-axis) is baseline-anchored, extending in one direction only. This means the same `mgp` formula that keeps gaps constant on the x-axis (even as `cex.lab` changes) will yield ever-increasing gaps on the y-axis 🙃

The upshot is a single `(t)par("mgp")` vector cannot produce correct spacing on both sides simultaneously. So we instead compute `mgp` once from a shared formula---using underlying spacing primitives---and  then apply side-specific corrections when drawing:

**Side 1 (x-axis):** No positional correction needed. R centers horizontal text on the specified margin line, so the standard `mgp` formula (`gap + 0.5*cex`) keeps gaps constant by construction. The only change is a tighter descent formula (`0.2*cex_lab + 0.8`) that tracks actual ink extent rather than the full cell height, preventing the bottom margin from growing with `cex`.

**Side 2 (y-axis):** Two on-the-fly corrections are applied at draw time:

- `ylab_cex_shift` (`0.5 * (cex_lab - 1)`): R places the baseline of rotated text at the specified line (not the cell center), so the  standard `mgp[1]` formula pushes `ylab` away from tick labels as `cex` grows. This shift cancels that drift, anchoring the visible gap constant.
- `ymgp_shift` (`0.5 * (cex_axis - 1)`): When `las` ∈ {0, 1}, y-axis tick labels extend sideways into the margin, not away from the plot edge. The scaled `mgp[2]` over-allocates vertical clearance that isn't needed. This removes the excess by temporarily adjusting `par(mgp)` around the `axis()` call.

(_Aside: Side 2's descent formula (`0.1*cex_lab + 0.9`) is shallower than side 1's, reflecting that the `cex_shift` already accounts for most of the outward extent._)

I mentioned "spacing primitives" above. These are two new user-facing `tpar()`/`tinytheme()` parameters: 1) `gap.axis` and  2) `gap.lab. This PR includes quite detailed documentation about each of these, so I won't go much into detail here. But in addition to facilitating the side-dependent draw-time optimization described above, they also provide a much more intuitive way to set axis label and title spacing for themes:

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
tinytheme("dynamic", gap.axis = 0, gap.lab = 0.5)
tinyplot(mpg ~ hp, data = mtcars, main = "Tighter axis gaps"); box("outer", lty = 2)
```

![](https://i.imgur.com/ZiMVIfe.png)<!-- -->

``` r
tinytheme("dynamic", gap.axis = 2, gap.lab = 2)
tinyplot(mpg ~ hp, data = mtcars, main = "Looser axis gaps"); box("outer", lty = 2)
```

![](https://i.imgur.com/eEu04qt.png)<!-- -->

``` r
tinytheme() # reset
```
 
 ### Gory details

_I told Claude to write out a detailed log of everything we learned while iterating through this problem. I might save it as additional context that gets auto-loaded in the future. For the moment, I'll just leave it here for posterity._ 

<details>
<summary>Click to expand: full technical writeup on R's margin text positioning model</summary>

# How R positions margin text: the gory details

This document records what we learned while implementing cex-aware dynamic
margins for tinyplot (#590). It covers how R's `title()` / `mtext()` actually
position text in margins, the asymmetry between horizontal and rotated text
placement, and the formulas we derived to keep gaps constant as `cex.lab` and
`cex.axis` scale.

## Background: what we're trying to achieve

tinyplot's `tinytheme()` computes margins dynamically based on what's actually
being drawn (labels, titles, ticks). When a user sets `cex.lab = 3` or
`cex.axis = 2`, the margins need to grow to accommodate the larger text. But
they should grow *just enough* — the visible gaps between elements (tick labels
↔ axis title, axis title ↔ figure edge) should remain constant regardless of
cex. No clipping, no growing whitespace.

This turned out to be much harder than expected because R's text positioning
model has undocumented asymmetries between horizontal and rotated text.

---

## The character cell model

R's margin system works in "lines" — one line equals `par("csi")` inches at
`cex = 1`. All `mgp`, `mar`, and `mtext(line=...)` values are in these units.
At `cex = k`, one character cell occupies `k` lines.

A character "cell" at a given cex occupies `1 * cex` lines vertically. But
glyphs don't fill the entire cell:

```r
strheight("X", units = "inches", cex = k) / par("csi")  # ≈ 0.597 * k
strheight("gyp descender", units = "inches", cex = k) / par("csi")  # ≈ 0.597 * k (same!)
```

Key facts:
- The glyph occupies ~60% of the cell; ~40% is internal leading
- `strheight()` returns the same value for ANY string at a given cex — "X",
  "gyp", "Gg" all give 0.597*k. It's a font-level line-height metric, not a
  per-glyph bounding box
- This ratio is constant across cex values (scales perfectly linearly)
- There is no R API to get actual glyph ascent/descent metrics

The consequence: at large cex, there's proportionally more unused space within
each cell. Any formula that uses `0.5*cex` (half-cell) to model the ink extent
will over-allocate space, and that over-allocation grows with cex.

---

## The mgp coordinate system

`par("mgp")` controls where margin text is placed:
- `mgp[1]`: line number for axis titles (xlab, ylab)
- `mgp[2]`: line number for tick labels
- `mgp[3]`: line number for the axis line itself

Lines are counted outward from the plot edge. Line 0 is the plot boundary;
larger values go further into the margin (toward the device edge).

In tinyplot's dynamic system, mgp is computed from spacing primitives:

```r
mgp[2] = gap.axis + 0.5 * cex_axis   # tick label center
mgp[1] = mgp[2] + gap.lab + 0.5 * cex_lab  # axis title center
```

Where `gap.axis` (default 0.2) is the gap from the tick tip to the near edge
of the tick label cell, and `gap.lab` (default 1.0) is the gap from the far
edge of the tick label cell to the near edge of the title cell.

---

## Side 1 (x-axis): horizontal text centering

`title(xlab=...)` places horizontal text such that the **cell center** sits at
`mgp[1]` margin lines from the plot edge.

```
    plot edge (line 0)
    |
    |  tick marks
    |  |
    |  | gap.axis (0.2 lines)
    |  |  |
    |  |  |  ┌─────────────────┐ ← mgp[2] + 0.5*cex_axis (far cell edge)
    |  |  |  │   tick labels   │   cell = cex_axis lines tall
    |  |  |  │    (centered)   │
    |  |  |  └─────────────────┘ ← mgp[2] - 0.5*cex_axis (near cell edge)
    |  |  |           |
    |  |  |           | gap.lab (1.0 lines)
    |  |  |           |
    |  |  |  ┌─────────────────┐ ← mgp[1] + 0.5*cex_lab (far cell edge)
    |  |  |  │   xlab title    │   cell = cex_lab lines tall
    |  |  |  │    (centered)   │
    |  |  |  └─────────────────┘ ← mgp[1] - 0.5*cex_lab (near cell edge)
    |  |  |           |
    |  |  |           | descent buffer
    |  |  |           |
    figure edge (line = mar[1])
```

The near edge of the title cell (toward ticks) is at:
```
mgp[1] - 0.5*cex_lab = (mgp[2] + gap.lab + 0.5*cex_lab) - 0.5*cex_lab = mgp[2] + gap.lab
```

The `cex_lab` terms cancel — the near edge is **constant regardless of
cex_lab**. This is why `0.5*cex` in the mgp formula keeps the gap between xlab
and tick labels fixed. The gap between adjacent text elements equals `gap.lab`
at all cex values.

### Side 1 descent formula

For the far edge (toward device boundary), the margin must extend past
`mgp[1]` by enough to contain the text plus a buffer. We use:

```r
descent = 0.2 * cex_lab + 0.8
```

Why not `0.5*cex_lab` (half-cell)?

- Ink only extends to ~0.3*cex below center (60% of half-cell = 0.3)
- R does NOT clip horizontal text at the cell boundary — only at the figure
  region boundary
- Using 0.5 would make the gap between xlab and the figure edge grow with cex
  (we tested this — the whitespace below the text visibly increases)
- Using 0.3 makes the gap shrink slightly (we tested — at cex=5 the text
  overlaps the tick labels)
- 0.2 was found empirically to keep the visible gap approximately constant

The 0.8 constant provides sufficient buffer for descenders at cex=1.
Empirically: clipping occurs when the total bottom margin drops below ~3.2
lines; working backward from the mgp formula gives a minimum buffer of ~0.8.

Verification: at cex_lab=1, descent = 1.0 (safe). At cex_lab=5, descent = 1.8.
The visible gap between ink bottom and figure edge stays approximately constant
because `0.2*cex` closely tracks the actual ink-to-cell-bottom distance.

---

## Side 2 (y-axis): rotated text — the critical asymmetry

**This is the non-obvious part.** `title(ylab=...)` places rotated (90°) text
completely differently from horizontal text.

### Discovery: baseline anchoring

Through empirical testing (drawing reference lines at predicted positions), we
determined that R places the **baseline** of rotated text at the specified
margin line. The text extends in ONE direction only — outward, toward the
device edge. Nothing extends toward the plot.

```
    figure edge                                         plot edge
    |                                                   |
    |  buffer  |←────── 0.6*cex ──────→|                |
    |          [======== Y label ========]              |
    |                                    ↑ baseline     |
    |                                    |              |
    |                                  mgp[1]           |
    |                                    |              |
    |                                    |← gap.lab →|  |
    |                                                tick labels
```

This is fundamentally different from side 1:
- Horizontal text: cell CENTER at mgp[1], text extends 0.5*cex in BOTH directions
- Rotated text: BASELINE at mgp[1], text extends ~0.6*cex in ONE direction (outward)

### Why this creates a growing gap

With the mgp formula `mgp[1] = mgp[2] + gap.lab + 0.5*cex_lab`, the baseline
moves outward by `0.5*cex_lab`. Since the baseline IS the near edge for rotated
text, the gap between ylab and tick labels is:

```
visible_gap = mgp[1] - (mgp[2] + 0.5*cex_axis)
            = gap.lab + 0.5*cex_lab - 0.5*cex_axis
            = gap.lab + 0.5*(cex_lab - cex_axis)
```

At cex_lab=1, cex_axis=1: gap = gap.lab = 1.0 (correct)
At cex_lab=3, cex_axis=1: gap = 1.0 + 1.0 = 2.0 (GROWING!)
At cex_lab=5, cex_axis=1: gap = 1.0 + 2.0 = 3.0 (way too much)

Meanwhile, the text extends 0.6*cex outward from the baseline. The total
extent from plot edge = mgp[1] + 0.6*cex, which grows faster than the margin,
causing clipping at large cex.

### The fix: ylab_cex_shift

We correct the positioning by subtracting `0.5*(cex_lab - 1)` from the line at
which ylab is drawn:

```r
.ylab_cex_shift = 0.5 * (.cex_lab - 1)
ylab_line = mgp[1] + whtsbp[2] - ymgp_shift - ylab_cex_shift
```

This cancels the `0.5*cex_lab` growth in mgp[1]. The effective baseline
position becomes:

```
effective_line = mgp[1] - 0.5*(cex_lab - 1)
               = mgp[2] + gap.lab + 0.5*cex_lab - 0.5*cex_lab + 0.5
               = mgp[2] + gap.lab + 0.5
```

This is constant regardless of cex_lab — the baseline (and thus the visible
gap to tick labels) stays anchored.

### Side 2 descent formula

With the shift applied, the text far edge is at:

```
far_edge = effective_line + 0.6*cex_lab
         = (mgp[1] - 0.5*(cex_lab-1)) + 0.6*cex_lab
         = mgp[1] + 0.1*cex_lab + 0.5
```

The margin needs `mgp[1] + descent` ≥ `far_edge + buffer`:

```
descent ≥ 0.1*cex_lab + 0.5 + buffer
```

With buffer = 0.4: **`descent = 0.1*cex_lab + 0.9`**

This gives exactly 1.0 at cex=1 (preserving existing snapshot behavior) while
maintaining constant clearance at all cex values:
- cex=1: descent=1.0, far_edge extends 0.6 past baseline → 0.4 buffer
- cex=3: descent=1.2, far_edge extends 1.8 past baseline → 0.4 buffer
- cex=5: descent=1.4, far_edge extends 3.0 past baseline → 0.4 buffer

---

## The ymgp_shift: why las=1 needs special treatment

### The problem

`par("mgp")` is a single global value — it applies to both x and y axes.
`mgp[2]` controls how far tick labels sit from the axis line.

On the **x-axis** (side 1), tick labels are horizontal text below the axis.
They extend downward (away from the plot) by `0.5*cex_axis`. The full `mgp[2]`
spacing is needed to prevent labels from overlapping into the plot region.

On the **y-axis** (side 2) with `las = 1` (horizontal tick labels), the labels
extend **leftward** into the margin, not toward the plot. The vertical extent
is minimal. So the scaled `mgp[2] = gap.axis + 0.5*cex_axis` creates
unnecessary vertical gap between the plot edge and where the tick labels sit.

```
   With las=1 and cex.axis=3:

   Horizontal y-tick labels extend LEFT, not DOWN:

   plot edge
   |
   |←── mgp[2] = 1.7 ──→|  ← labels drawn here (way too far from edge!)
   |                      |
   |    10                |
   |     8                |
   |     6                |  ← big unnecessary gap between labels and plot edge
   |     4                |
   |     2                |
```

This gap is correct for side 1 (where vertical extent matters) but wrong for
side 2 with las=1 (where labels go sideways).

### The fix

We compute the excess `mgp[2]` beyond what cex=1 needs:

```r
.ymgp_shift = if (las %in% c(0, 1)) 0.5 * (cex_axis - 1) else 0
```

This is applied in two places:

1. **Margin calculation**: subtract from the left margin so it doesn't
   over-allocate space for the non-existent vertical extent:
   ```r
   if (.ymgp_shift > 0) .dyn[2] = .dyn[2] - .ymgp_shift
   ```

2. **Axis drawing** (in `facet.R`): temporarily reduce `par(mgp[2])` before
   drawing the y-axis, then restore:
   ```r
   par(mgp = par("mgp") - c(0, .ymgp_shift, 0))
   axis(side = 2, ...)
   par(mgp = par("mgp") + c(0, .ymgp_shift, 0))
   ```

3. **ylab positioning**: subtract from the ylab line offset so the title
   doesn't inherit the excess spacing:
   ```r
   ylab_line_offset = whtsbp[2] - .ymgp_shift - .ylab_cex_shift
   ```

### Why not axis(line = -X)?

We tried `axis(side = 2, line = -shift)` first. This moves the ENTIRE axis
inward — the axis line, tick marks, AND labels all shift toward the plot. But
we only want to move the labels; the axis line should stay at the plot edge
(aligned with `box()`). The `par(mgp)` override is the correct approach because
mgp only controls label and title positioning, not the axis line or tick marks
(those use `tcl`).

### When does ymgp_shift apply?

Only when `las %in% c(0, 1)`:
- `las = 0`: labels parallel to axis. Y-axis labels are rotated 90°, extending
  leftward. Same situation as las=1 — vertical extent is just the strheight.
- `las = 1`: labels always horizontal. Same reasoning.
- `las = 2`: labels perpendicular to axis. Y-axis labels are horizontal (same
  as las=1 for side 2 — but this is the default for las=2 on side 1 too, so
  the shift logic could interfere; we skip it for safety).
- `las = 3`: labels always vertical. Y-axis labels extend downward — the full
  mgp[2] IS needed. No shift.

---

## whtsbp: tick label width/height bump

`whtsbp` (width/height tick label bump) accounts for tick labels that extend
further into the margin than `mgp[2]` alone predicts. This matters when:

- y-axis labels are wide (e.g., "10,000,000") with las=1
- x-axis labels are tall (e.g., rotated long strings) with las=2

The bump is computed from actual rendered string widths:

```r
whtsbp_y = grconvertX(max(strwidth(yaxlabs, "figure", cex = cex_axis)), from = "nfc", to = "lines") - 1
```

The `-1` subtracts the one line that `mgp[2]` already allocates for a
"standard" label width. The result is added to both the margin AND the ylab
line offset, pushing the title further out to accommodate wide labels.

---

## Summary of all formulas

| Component | Formula | What it does |
|-----------|---------|--------------|
| mgp[2] | `gap.axis + 0.5*cex_axis` | Tick label cell center position |
| mgp[1] | `mgp[2] + gap.lab + 0.5*cex_lab` | Title cell center position (correct for side 1) |
| descent (side 1) | `0.2*cex_lab + 0.8` | Margin below xlab: ink extent + fixed buffer |
| descent (side 2) | `0.1*cex_lab + 0.9` | Margin left of ylab: accounts for cex_shift, gives 1.0 at cex=1 |
| tick_extent | `max(0,-tcl) + mgp[2] + 0.4*cex_axis + 0.6` | Margin for tick labels alone (no title) |
| ymgp_shift | `0.5*(cex_axis - 1)` | Remove excess mgp[2] gap for las=0,1 y-axis |
| ylab_cex_shift | `0.5*(cex_lab - 1)` | Anchor rotated ylab baseline near ticks |

### Default gap primitives

| Parameter | Default | Meaning |
|-----------|---------|---------|
| gap.axis | 0.2 | Lines from tick tip to tick label cell near edge |
| gap.lab | 1.0 | Lines from tick label cell far edge to title cell near edge |

---

## Key gotchas for future work

1. **strheight() is useless for per-glyph measurement.** It returns the same
   value for any string at a given cex. It measures the font's line height
   (~0.6 of the cell), not actual ink bounds. There is no R API to get true
   ascent/descent metrics for specific glyphs. Don't rely on it for
   distinguishing characters with descenders from those without.

2. **Horizontal vs rotated text use completely different anchoring.** Horizontal
   text: cell center at specified line, extends both directions. Rotated text:
   baseline at specified line, extends one direction only. Any formula derived
   for one axis will NOT work for the other without a correction term.

3. **R clips differently for horizontal vs rotated text.** Horizontal text can
   bleed past the cell boundary without being clipped (only the figure region
   boundary clips). Rotated text appears to clip at or very near the cell
   boundary. This is why the side-1 descent can be tighter (0.2*cex) than
   what the cell model predicts (0.5*cex).

4. **mgp is global — it cannot differ between sides.** Any side-specific
   correction must happen at draw time via: (a) line offsets passed to
   `title()`, (b) temporary `par(mgp=...)` overrides around `axis()` calls, or
   (c) post-hoc adjustment variables like `ymgp_shift` and `ylab_cex_shift`.

5. **The 0.5 in mgp is correct even though ink is only 0.3.** The cancellation
   that keeps the near-edge gap constant depends on having `0.5*cex` in BOTH
   the mgp formula AND the cell-edge model. Using 0.3 (the ink extent) would
   make the gap shrink as cex grows, because R still positions at the cell
   center — the unused cell padding on the near side gets eaten into the gap.
   We confirmed this empirically: 0.3 caused the xlab to drift into the tick
   labels at cex=5.

6. **The gap between ink edges is NOT the same as gap.axis/gap.lab.** These
   primitives represent cell-edge to cell-edge distance. The visible gap between
   ink is larger by the internal leading of both adjacent cells (~0.2*cex each
   side = ~0.4*cex total). This is acceptable because the important property is
   constancy, not absolute value. Users control the visual spacing by adjusting
   the gap primitives.

7. **recordGraphics() is required for resize correctness.** All of these
   calculations depend on device dimensions (strwidth, grconvertX). If they run
   once at initial draw time, resizing the window will misalign everything.
   Coordinate-dependent calculations (especially legends) must be wrapped in
   `recordGraphics()` so they replay on resize.

---

## Empirical methodology

The formulas above were derived through iterative visual testing:

1. Generate plots at cex.lab = 1, 3, 5 with `box("inner", lty=2)` (plot
   region) and `box("figure", col="red", lty=3)` (figure region)
2. Draw reference lines at predicted cell edges using `grconvertX(...,
   from="lines", to="user")` to verify where R actually renders text
3. Sweep coefficient values (0.2, 0.3, 0.4, 0.5) and observe which keeps
   gaps constant on both the near and far edges simultaneously
4. The "green/red/blue line" test was decisive for discovering the rotated
   text baseline behaviour — it showed that the cell center prediction was
   wrong, and the baseline prediction matched perfectly

### Diagnostic technique: colored reference lines

The technique that cracked the positioning problem was drawing colored vertical
lines in the left margin at positions predicted by different anchoring models,
then seeing which line aligned with which text edge. This general approach —
"draw what you predict, then see if reality matches" — is invaluable for any
future margin/positioning work in R.

#### Script 1: Discovery (run WITHOUT ylab_cex_shift)

This is the test that revealed the asymmetry. It assumes the cell-center model
(which works for side 1 horizontal text) and draws three predictions. The
mismatch between predictions and rendered text proves that rotated text uses
baseline anchoring instead.

To reproduce the original discovery, temporarily comment out the
`.ylab_cex_shift` line in `tinyplot.R` before running.

```r
library(tinyplot)

cex_lab = 5     # try 1, 3, 5 — differences most visible at large cex
cex_axis = 1

tinytheme("clean", cex.lab = cex_lab, cex.axis = cex_axis)
tinyplot(1:10, xlab = "gyp descender test", ylab = "Y label",
         main = sprintf("cex.lab = %g (no cex_shift)", cex_lab))

mgp1 = par("mgp")[1]
par(xpd = TRUE)  # allow drawing into margins

# 1 margin line in user-x units (side 2 lines go leftward from plot edge)
lh = par("csi") / par("pin")[1] * diff(par("usr")[1:2])
plot_left = par("usr")[1]

# Three predictions under the cell-center model:
#   Blue  = near edge:  mgp[1] - 0.5*cex (toward ticks)
#   Green = center:     mgp[1] (where cell midpoint "should" be)
#   Red   = far edge:   mgp[1] + 0.5*cex (toward device)
near_x   = plot_left - (mgp1 - 0.5 * cex_lab) * lh
center_x = plot_left - mgp1 * lh
far_x    = plot_left - (mgp1 + 0.5 * cex_lab) * lh

abline(v = near_x,   col = "blue",   lty = 2, lwd = 2)
abline(v = center_x, col = "green3", lty = 3, lwd = 2)
abline(v = far_x,    col = "red",    lty = 2, lwd = 2)

legend("topright", lty = c(2, 3, 2), lwd = 2, col = c("blue", "green3", "red"),
       legend = c("predicted near edge", "predicted center (mgp[1])",
                  "predicted far edge"), cex = 0.8)

par(xpd = FALSE)
tinytheme()
```

**What we observed (without cex_shift):**
- The **bottom** (near edge) of the rendered "Y label" text always sits on
  the **green** line — the predicted *center*, i.e., raw `mgp[1]`
- The **middle** of the text sits near the **red** line (predicted far edge)
- The text **never reaches** the **blue** line (predicted near edge)

**Interpretation:** If the cell-center model were correct, the green line
would be at the text midpoint and blue/red would bracket it equally. Instead,
the green line is at the text's *near edge*. This proves R places the
**baseline** (not cell center) at `mgp[1]` for rotated text. The text extends
only leftward (~0.6*cex lines) from the baseline.

#### Script 2: Verification (run WITH ylab_cex_shift, i.e. current code)

After applying the fix, run this to verify the correction works. The reference
lines now show the *corrected* effective positions.

```r
library(tinyplot)

cex_lab = 5     # try 1, 3, 5
cex_axis = 1

tinytheme("clean", cex.lab = cex_lab, cex.axis = cex_axis)
tinyplot(1:10, xlab = "gyp descender test", ylab = "Y label",
         main = sprintf("cex.lab = %g (with cex_shift)", cex_lab))

mgp1 = par("mgp")[1]
par(xpd = TRUE)

lh = par("csi") / par("pin")[1] * diff(par("usr")[1:2])
plot_left = par("usr")[1]

# With the shift applied, the effective baseline is at:
#   mgp[1] - 0.5*(cex_lab - 1)
# This should be constant regardless of cex_lab.
cex_shift = 0.5 * (cex_lab - 1)
effective_baseline = mgp1 - cex_shift

baseline_x = plot_left - effective_baseline * lh
far_x      = plot_left - (effective_baseline + 0.6 * cex_lab) * lh

abline(v = baseline_x, col = "green3", lty = 2, lwd = 2)
abline(v = far_x,      col = "red",    lty = 2, lwd = 2)

# Also show where the margin boundary is (should clear far_x)
mar_edge = plot_left - par("mar")[2] * lh
abline(v = mar_edge, col = "orange", lty = 3, lwd = 2)

legend("topright", lty = c(2, 2, 3), lwd = 2,
       col = c("green3", "red", "orange"),
       legend = c("effective baseline (near edge of text)",
                  "predicted far edge (0.6*cex past baseline)",
                  "figure edge (margin boundary)"),
       cex = 0.8)

par(xpd = FALSE)
tinytheme()
```

**What to check:**
- Green line should align with the **right/near edge** of the ylab text
  (the side closest to the tick labels), confirming the shift anchored it
- Red line should align with or slightly undershoot the **left/far edge**
  of the text ink
- Orange line (figure edge) should sit to the left of the red line with
  ~0.4 lines of clearance — never overlapping the text

#### General technique for future margin debugging

1. **Formulate a hypothesis** about where R places text (e.g., "cell center
   at line X")
2. **Derive predicted positions** for the edges (near, center, far) under
   that hypothesis
3. **Convert line positions to user coordinates** using:
   ```r
   lh = par("csi") / par("pin")[axis_dim] * diff(par("usr")[axis_range])
   position = plot_edge - line_number * lh  # side 2 (left margin)
   position = plot_edge + line_number * lh  # side 1 (bottom margin, y-axis)
   ```
4. **Draw with `par(xpd = TRUE)`** so lines extend into margins
5. **Compare predictions against rendered text** — if one line consistently
   aligns with an unexpected edge, your anchoring model is wrong
6. **Test at multiple cex values** (1, 3, 5) — errors in the model that are
   invisible at cex=1 become obvious at cex=5

This same approach works for debugging side 1 (horizontal text), side 3/4,
`mtext()` positioning, or any margin placement issue.


</details>