### PR TITLE
Better `ribbon.alpha` for `"dark"` theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,9 +60,10 @@ visualizations.
 - **Theme refinements**. The `"tufte"` and `"void"` themes are now dynamic
   (responsive margins). The `"ipsum"` theme has been overhauled (bold title, no
   ticks, fine grid, custom palette); the original variant is preserved as
-  `"ipsum2"`. The `"bw"` and `"classic"` themes now use smaller axis text and
-  tighter spacing to better match their ggplot2 counterparts.
-  (#595 @grantmcdermott)
+  `"ipsum2"`. The ggplot2-inspired like `"bw"` and `"classic"` now use smaller
+  axis text and tighter spacing to better match their ggplot2 counterparts. 
+  Also, the `"dark"` theme now uses a better default `ribbon.alpha` for better
+  contrast against the black background. (#595, #603 @grantmcdermott)
 
 ### New features
 

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -325,6 +325,7 @@ theme_default = list(
   # palette.qualitative = "R4",
   # palette.sequential = "Viridis",
   pch = par("pch"), # 1,
+  ribbon.alpha = 0.2,
   side.sub = 1,
   tck = NA,
   tcl = par("tcl"), # -0.5
@@ -480,7 +481,8 @@ theme_dark = modifyList(theme_minimal, list(
   # facet.bg = "gray20",
   grid.col = "#6D6D6D",
   palette.qualitative = "Set 2",
-  palette.sequential = "Sunset"
+  palette.sequential = "Sunset",
+  ribbon.alpha = 0.5
 ))
 
 # derivatives of clean/clean2


### PR DESCRIPTION
Closes #602.

After some experimentation, I settled on `0.5`.