### PR TITLE
Docs tweak

### DIFF
--- a/R/type_density.R
+++ b/R/type_density.R
@@ -3,6 +3,8 @@
 #' @md
 #' @description Type function for density plots.
 #' @inheritParams stats::density
+#' @param bw the smoothing \code{\link[stats:bw.nrd]{bandwidth}} to be used,
+#'   see \code{\link[stats]{density}} for details and options.
 #' @param kernel a character string giving the smoothing kernel to be used. This
 #'   must partially match one of `"gaussian"`, `"rectangular"`, `"triangular"`,
 #'   `"epanechnikov"`, `"biweight"`, `"cosine"` or `"optcosine"`, with default

--- a/R/type_ridge.R
+++ b/R/type_ridge.R
@@ -30,6 +30,8 @@
 #' @param ylevels a character or numeric vector specifying in which order
 #' the levels of the y-variable should be plotted.
 #' @inheritParams stats::density
+#' @param bw the smoothing \code{\link[stats:bw.nrd]{bandwidth}} to be used,
+#'   see \code{\link[stats]{density}} for details and options.
 #' @param kernel a character string giving the smoothing kernel to be used. This
 #'   must partially match one of `"gaussian"`, `"rectangular"`, `"triangular"`,
 #'   `"epanechnikov"`, `"biweight"`, `"cosine"` or `"optcosine"`, with default

--- a/R/type_spline.R
+++ b/R/type_spline.R
@@ -5,7 +5,8 @@
 #' for default argument values.
 #'
 #' @inheritParams stats::spline
-#' @inherit stats::spline details
+#' @details See \code{\link[stats]{spline}} for further details on the available
+#'   interpolation methods.
 #' @importFrom stats spline
 #' @examples
 #' # "spline" type convenience string

--- a/R/type_violin.R
+++ b/R/type_violin.R
@@ -12,6 +12,7 @@
 #' @inherit stats::density details
 #' @details See [`type_density`] for more details and considerations related to
 #'   bandwidth selection and kernel types.
+#'
 #'   
 #' @examples
 #' # "violin" type convenience string

--- a/man/type_density.Rd
+++ b/man/type_density.Rd
@@ -15,20 +15,8 @@ type_density(
 )
 }
 \arguments{
-\item{bw}{the smoothing bandwidth to be used.  The kernels are scaled
-    such that this is the standard deviation of the smoothing kernel.
-    (Note this differs from the reference books cited below.)
-
-    \code{bw} can also be a character string giving a rule to choose the
-    bandwidth.  See \code{\link[stats]{bw.nrd}}. \cr The default,
-    \code{"nrd0"}, has remained the default for historical and
-    compatibility reasons, rather than as a general recommendation,
-    where e.g., \code{"SJ"} would rather fit, see also
-    {\if{html}{\cite{}\out{<a href="#reference+density.Rd+R+3AVenables+2BRipley+3A2002" class="citation">}}Venables and Ripley (2002)\if{html}{\out{</a>}}}.
-
-    The specified (or computed) value of \code{bw} is multiplied by
-    \code{adjust}.
-  }
+\item{bw}{the smoothing \code{\link[stats:bw.nrd]{bandwidth}} to be used,
+see \code{\link[stats]{density}} for details and options.}
 
 \item{joint.bw}{character string indicating whether (and how) the smoothing
 bandwidth should be computed from the joint data distribution when there

--- a/man/type_ridge.Rd
+++ b/man/type_ridge.Rd
@@ -49,20 +49,8 @@ at the specified \code{probs}. The quantiles are computed based on the density
 \item{ylevels}{a character or numeric vector specifying in which order
 the levels of the y-variable should be plotted.}
 
-\item{bw}{the smoothing bandwidth to be used.  The kernels are scaled
-    such that this is the standard deviation of the smoothing kernel.
-    (Note this differs from the reference books cited below.)
-
-    \code{bw} can also be a character string giving a rule to choose the
-    bandwidth.  See \code{\link[stats]{bw.nrd}}. \cr The default,
-    \code{"nrd0"}, has remained the default for historical and
-    compatibility reasons, rather than as a general recommendation,
-    where e.g., \code{"SJ"} would rather fit, see also
-    {\if{html}{\cite{}\out{<a href="#reference+density.Rd+R+3AVenables+2BRipley+3A2002" class="citation">}}Venables and Ripley (2002)\if{html}{\out{</a>}}}.
-
-    The specified (or computed) value of \code{bw} is multiplied by
-    \code{adjust}.
-  }
+\item{bw}{the smoothing \code{\link[stats:bw.nrd]{bandwidth}} to be used,
+see \code{\link[stats]{density}} for details and options.}
 
 \item{joint.bw}{character string indicating whether (and how) the smoothing
 bandwidth should be computed from the joint data distribution. The default

--- a/man/type_spline.Rd
+++ b/man/type_spline.Rd
@@ -40,30 +40,8 @@ Arguments are passed to \code{\link[stats]{spline}}; see this latter function
 for default argument values.
 }
 \details{
-The inputs can contain missing values which are deleted, so at least
-  one complete \code{(x, y)} pair is required.
-  If \code{method = "fmm"}, the spline used is that of
-  {\if{html}{\cite{}\out{<a href="#reference+splinefun.Rd+R+3AForsythe+2BMalcolm+2BMoler+3A1977" class="citation">}}Forsythe, Malcolm, and Moler (1977)\if{html}{\out{</a>}}}
-  (an exact cubic is fitted through the four points at each
-  end of the data, and this is used to determine the end conditions).
-  Natural splines are used when \code{method = "natural"}, and periodic
-  splines when \code{method = "periodic"}.
-
-  The method \code{"monoH.FC"} computes a \emph{monotone} Hermite spline
-  according to the method of Fritsch and Carlson.  It does so by
-  determining slopes such that the Hermite spline, determined by
-  \eqn{(x_i,y_i,m_i)}{(x[i],y[i],m[i])}, is monotone (increasing or
-  decreasing) \bold{iff} the data are.
-
-  Method \code{"hyman"} computes a \emph{monotone} cubic spline using
-  Hyman filtering of an \code{method = "fmm"} fit for strictly monotonic
-  inputs.
-
-  These interpolation splines can also be used for extrapolation, that is
-  prediction at points outside the range of \code{x}.  Extrapolation
-  makes little sense for \code{method = "fmm"}; for natural splines it
-  is linear using the slope of the interpolating curve at the nearest
-  data point.
+See \code{\link[stats]{spline}} for further details on the available
+interpolation methods.
 }
 \examples{
 # "spline" type convenience string

--- a/man/type_violin.Rd
+++ b/man/type_violin.Rd
@@ -16,20 +16,8 @@ type_violin(
 )
 }
 \arguments{
-\item{bw}{the smoothing bandwidth to be used.  The kernels are scaled
-    such that this is the standard deviation of the smoothing kernel.
-    (Note this differs from the reference books cited below.)
-
-    \code{bw} can also be a character string giving a rule to choose the
-    bandwidth.  See \code{\link[stats]{bw.nrd}}. \cr The default,
-    \code{"nrd0"}, has remained the default for historical and
-    compatibility reasons, rather than as a general recommendation,
-    where e.g., \code{"SJ"} would rather fit, see also
-    {\if{html}{\cite{}\out{<a href="#reference+density.Rd+R+3AVenables+2BRipley+3A2002" class="citation">}}Venables and Ripley (2002)\if{html}{\out{</a>}}}.
-
-    The specified (or computed) value of \code{bw} is multiplied by
-    \code{adjust}.
-  }
+\item{bw}{the smoothing \code{\link[stats:bw.nrd]{bandwidth}} to be used,
+see \code{\link[stats]{density}} for details and options.}
 
 \item{joint.bw}{character string indicating whether (and how) the smoothing
 bandwidth should be computed from the joint data distribution when there


### PR DESCRIPTION
Fix minor R CMD check NOTE

(Using the `@inheritParams stats::density` tag triggers a `checkRd: Lost braces` NOTE related to the `bw` citation parsing.)