### PR TITLE
offset for `type_barplot`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -143,6 +143,9 @@ Theme fixes:
   `plt(..., facet = ~z, facet.args = list(ncol = 1))`. Analogously,
   `plt(..., facet = 1 ~ z)` can be used as a shortcut for
   `plt(..., facet = ~ z, facet.args = list(nrow = 1))`. (#562 @zeileis)
+- `type_barplot()` gains an `offset` argument for shifting bar baselines away
+  from zero. Accepts a scalar or per-x-level numeric vector. Useful for
+  waterfall plots and floating bars. (#611 @grantmcdermott)
 
 ### Bug fixes
 

--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -136,9 +136,10 @@ labeller_fun = function(label = "percent") {
   format_percent = function(x) {
     max_decimals = 5L
     pct = as.numeric(x) * 100
+    upct = unique(pct)
     d = Find(
       function(d) {
-        length(unique(sprintf(paste0('%.', d, 'f%%'), pct))) == length(pct)
+        length(unique(sprintf(paste0('%.', d, 'f%%'), upct))) == length(upct)
       },
       0:max_decimals
     ) %||%

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -24,6 +24,11 @@
 #'   (if numeric) for the plot.
 #' @param xaxlabels a character vector with the axis labels for the `x` variable,
 #'   defaulting to the levels of `x`.
+#' @param offset numeric. Optional vertical offset(s) for bar baselines. When
+#'   provided, bars start at the offset value(s) rather than zero. Accepts
+#'   either a single scalar (applied to all bars) or a numeric vector with one
+#'   value per x-level (matched after any `xlevels` reordering).
+#'   Cannot be combined with `center`.
 #' @param drop.zeros logical. Should bars with zero height be dropped? If set
 #'   to `FALSE` (default) a zero height bar is still drawn for which the border
 #'   lines will still be visible.
@@ -64,11 +69,20 @@
 #'   center = TRUE, flip = TRUE, facet.args = list(ncol = 1), yaxl = "percent")
 #'
 #' tinytheme()
-#' 
+#'
+#' # Manualy waterfall plot example using offset
+#' d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
+#'                value = c(100, 40, -80, -10, 60))
+#' d$item = factor(d$item, levels = d$item)
+#' d$offset = c(0, cumsum(d$value[1:3]), 0)
+#' tinyplot(value ~ item | I(value < 0), data = d,
+#'   type = type_barplot(offset = d$offset), legend = FALSE)
+#' tinyplot_add(type = type_vline(4.5), lty = 2)
+#'
 #' @export
-type_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL, xlevels = NULL, xaxlabels = NULL, drop.zeros = FALSE) {
+type_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NULL, FUN = NULL, xlevels = NULL, xaxlabels = NULL, drop.zeros = FALSE) {
   out = list(
-    data = data_barplot(width = width, beside = beside, center = center, FUN = FUN, xlevels = xlevels, xaxlabels = xaxlabels, drop.zeros = drop.zeros),
+    data = data_barplot(width = width, beside = beside, center = center, offset = offset, FUN = FUN, xlevels = xlevels, xaxlabels = xaxlabels, drop.zeros = drop.zeros),
     draw = draw_rect(),
     name = "barplot"
   )
@@ -77,7 +91,7 @@ type_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
 }
 
 #' @importFrom stats aggregate
-data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL, xlevels = NULL, xaxlabels = NULL, drop.zeros = FALSE) {
+data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NULL, FUN = NULL, xlevels = NULL, xaxlabels = NULL, drop.zeros = FALSE) {
     fun = function(settings, ...) {
         env2env(
           settings,
@@ -111,13 +125,30 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
         if (!is.factor(datapoints$by)) datapoints$by = factor(datapoints$by)
         if (!is.factor(datapoints$facet)) datapoints$facet = factor(datapoints$facet)
         
-        if (isFALSE(null_by) && isFALSE(facet_by) && !beside && any(datapoints$y < 0)) {
+        if (!is.null(offset)) {
+          if (!is.numeric(offset)) stop("'offset' must be numeric")
+          if (!isFALSE(center)) {
+            warning("'offset' cannot be combined with 'center'; ignoring 'center'")
+            center = FALSE
+          }
+          nx_levels = nlevels(datapoints$x)
+          if (length(offset) == 1L) {
+            offset = rep(offset, nx_levels)
+          } else if (length(offset) != nx_levels) {
+            stop(sprintf(
+              "'offset' must be length 1 or %d (number of x levels), got %d",
+              nx_levels, length(offset)
+            ))
+          }
+        }
+        if (is.null(offset) && isFALSE(null_by) && isFALSE(facet_by) && !beside && any(datapoints$y < 0)) {
           warning("'beside' must be TRUE if there are negative 'y' values")
           beside = TRUE
         }
         if (beside & !isFALSE(center)) {
           warning("'center' is currently only supported for 'beside = FALSE'")
         }
+        null_ylim = is.null(ylim)
         offset_sum = function(z, center = TRUE, na.rm = TRUE) {
           n = length(z)
           if (isFALSE(center) || n < 1L) return(0)
@@ -153,7 +184,7 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
           nx = nlevels(df$x)
           nb = nlevels(df$by)
           
-          if (beside) {        
+          if (beside) {
             xl = as.numeric(df$x) - width/2 + (as.numeric(df$by) - 1) * width/nb * as.numeric(!facet_by)
             xr = if (facet_by) xl + width else xl + width/nb
             yb = 0
@@ -185,7 +216,17 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
         datapoints$nx = NULL
         xlabs = 1L:nx
         names(xlabs) = levels(datapoints$x)
-        
+
+        # Apply offset: shift bar baselines after rectangle computation
+        if (!is.null(offset)) {
+          off = offset[as.numeric(datapoints$x)]
+          datapoints$ymin = datapoints$ymin + off
+          datapoints$ymax = datapoints$ymax + off
+          if (null_ylim) {
+            ylim = range(c(0, datapoints$ymin, datapoints$ymax), na.rm = TRUE) * 1.02
+          }
+        }
+
         if (!isFALSE(center)) {
           if (is.null(yaxl)) {
             yaxl = abs

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -72,7 +72,7 @@
 #'
 #' # Manual waterfall plot example using offset
 #' d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
-#'                value = c(100, 40, -80, -10, 60))
+#'                value = c(100, 40, -80, -10, 50))
 #' d$item = factor(d$item, levels = d$item)
 #' d$offset = c(0, cumsum(d$value[1:3]), 0)
 #' tinyplot(value ~ item | I(value < 0), data = d,

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -70,7 +70,7 @@
 #'
 #' tinytheme()
 #'
-#' # Manualy waterfall plot example using offset
+#' # Manual waterfall plot example using offset
 #' d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
 #'                value = c(100, 40, -80, -10, 60))
 #' d$item = factor(d$item, levels = d$item)

--- a/inst/tinytest/_tinysnapshot/barplot_offset_beside_group.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_beside_group.svg
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='468.90' y='236.43' width='16.75' height='16.75' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='468.90' y='254.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<text x='484.52' y='225.00' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>group</text>
+<text x='488.07' y='248.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='488.07' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0NTIuMDd8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='452.07' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0NTIuMDd8MC4wMHw1MDQuMDA=)'>
+<text x='255.56' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>ID</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.67px' lengthAdjust='spacingAndGlyphs'>extra</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='89.02' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='126.03' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='163.03' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='200.04' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='237.05' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='274.06' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='311.07' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='348.08' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='385.09' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='422.10' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='59.04' y1='399.16' x2='59.04' y2='91.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='399.16' x2='51.84' y2='399.16' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='347.86' x2='51.84' y2='347.86' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='296.56' x2='51.84' y2='296.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='245.26' x2='51.84' y2='245.26' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='193.96' x2='51.84' y2='193.96' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='142.66' x2='51.84' y2='142.66' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='91.36' x2='51.84' y2='91.36' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,399.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,347.86) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,296.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text transform='translate(41.76,245.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text transform='translate(41.76,193.96) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text transform='translate(41.76,142.66) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,91.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDUyLjA3fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='393.03' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDUyLjA3fDU5LjA0fDQzMC41Ng==)'>
+<rect x='73.60' y='311.95' width='15.42' height='35.91' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='110.61' y='347.86' width='15.42' height='82.08' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='147.61' y='347.86' width='15.42' height='10.26' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='184.62' y='347.86' width='15.42' height='61.56' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='221.63' y='347.86' width='15.42' height='5.13' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='258.64' y='173.44' width='15.42' height='174.42' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='295.65' y='158.05' width='15.42' height='189.81' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='332.66' y='306.82' width='15.42' height='41.04' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='369.67' y='347.86' width='15.42' height='0.00' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='406.68' y='245.26' width='15.42' height='102.60' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='89.02' y='250.39' width='15.42' height='97.47' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='126.03' y='306.82' width='15.42' height='41.04' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='163.03' y='291.43' width='15.42' height='56.43' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='200.04' y='342.73' width='15.42' height='5.13' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='237.05' y='347.86' width='15.42' height='5.13' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='274.06' y='122.14' width='15.42' height='225.72' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='311.07' y='65.71' width='15.42' height='282.15' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='348.08' y='265.78' width='15.42' height='82.08' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='385.09' y='111.88' width='15.42' height='235.98' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='422.10' y='173.44' width='15.42' height='174.42' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/barplot_offset_flip.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_flip.svg
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<line x1='59.04' y1='430.56' x2='465.63' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='430.56' x2='59.04' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='160.69' y1='430.56' x2='160.69' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='262.33' y1='430.56' x2='262.33' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='363.98' y1='430.56' x2='363.98' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='465.63' y1='430.56' x2='465.63' y2='437.76' style='stroke-width: 0.75;' />
+<text x='59.04' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='160.69' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='262.33' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='363.98' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='465.63' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text transform='translate(41.76,366.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text transform='translate(41.76,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text transform='translate(41.76,123.39) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>C</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<rect x='160.69' y='315.62' width='254.12' height='101.18' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='262.33' y='194.21' width='152.47' height='101.18' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='109.86' y='72.80' width='355.76' height='101.18' style='stroke-width: 0.75; fill: #BEBEBE;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/barplot_offset_scalar.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_scalar.svg
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>ID</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.67px' lengthAdjust='spacingAndGlyphs'>extra</text>
+<text x='90.67' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='129.72' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='168.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='207.82' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='246.87' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='285.93' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='324.98' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='364.03' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='403.08' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='442.13' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='59.04' y1='430.56' x2='59.04' y2='111.52' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='430.56' x2='51.84' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='377.39' x2='51.84' y2='377.39' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='324.21' x2='51.84' y2='324.21' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='271.04' x2='51.84' y2='271.04' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='217.87' x2='51.84' y2='217.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='164.69' x2='51.84' y2='164.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='111.52' x2='51.84' y2='111.52' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,430.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,377.39) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text transform='translate(41.76,324.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text transform='translate(41.76,271.04) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text transform='translate(41.76,217.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text transform='translate(41.76,164.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,111.52) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>12</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<rect x='74.40' y='146.08' width='32.54' height='18.61' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='113.45' y='164.69' width='32.54' height='42.54' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='152.50' y='164.69' width='32.54' height='5.32' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='191.55' y='164.69' width='32.54' height='31.90' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='230.60' y='164.69' width='32.54' height='2.66' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='269.65' y='74.30' width='32.54' height='90.39' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='308.71' y='66.32' width='32.54' height='98.37' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='347.76' y='143.43' width='32.54' height='21.27' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='386.81' y='164.69' width='32.54' height='0.00' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='425.86' y='111.52' width='32.54' height='53.17' style='stroke-width: 0.75; fill: #BEBEBE;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/barplot_offset_stacked.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_stacked.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='452.90' y='236.43' width='16.75' height='16.75' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='452.90' y='254.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<text x='476.52' y='225.00' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='46.69px' lengthAdjust='spacingAndGlyphs'>Survived</text>
+<text x='472.07' y='248.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='15.34px' lengthAdjust='spacingAndGlyphs'>No</text>
+<text x='472.07' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>Yes</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MzYuMDd8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='436.07' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MzYuMDd8MC4wMHw1MDQuMDA=)'>
+<text x='247.56' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>Sex</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.67px' lengthAdjust='spacingAndGlyphs'>Freq</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='152.35' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.02px' lengthAdjust='spacingAndGlyphs'>Male</text>
+<text x='342.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>Female</text>
+<line x1='59.04' y1='430.56' x2='59.04' y2='130.16' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='430.56' x2='51.84' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='355.46' x2='51.84' y2='355.46' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='280.36' x2='51.84' y2='280.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='205.26' x2='51.84' y2='205.26' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='130.16' x2='51.84' y2='130.16' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,430.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,355.46) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,280.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,205.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,130.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDM2LjA3fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='377.03' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDM2LjA3fDU5LjA0fDQzMC41Ng==)'>
+<rect x='73.00' y='148.93' width='158.68' height='131.43' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='263.42' y='66.32' width='158.68' height='63.84' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='73.00' y='148.93' width='158.68' height='0.00' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='263.42' y='66.32' width='158.68' height='0.00' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/barplot_offset_waterfall.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_waterfall.svg
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text x='116.14' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='216.31' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.00px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='316.49' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>C</text>
+<text x='416.66' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<line x1='59.04' y1='430.56' x2='59.04' y2='66.32' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='430.56' x2='51.84' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='339.50' x2='51.84' y2='339.50' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='248.44' x2='51.84' y2='248.44' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='157.38' x2='51.84' y2='157.38' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='66.32' x2='51.84' y2='66.32' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,430.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,339.50) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,248.44) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,157.38) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,66.32) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<rect x='74.40' y='248.44' width='83.48' height='182.12' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='174.57' y='157.38' width='83.48' height='91.06' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='274.75' y='157.38' width='83.48' height='54.64' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='374.92' y='66.32' width='83.48' height='145.69' style='stroke-width: 0.75; fill: #BEBEBE;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-type_barplot.R
+++ b/inst/tinytest/test-type_barplot.R
@@ -87,3 +87,56 @@ f = function() {
   tinyplot(~ Species, data = iris)
 }
 expect_snapshot_plot(f, label = "barplot_formula_univariate")
+
+
+#
+## offset argument
+
+# Scalar offset shifts all bars
+f = function() {
+  tinyplot(extra ~ ID, data = sleep[sleep$group == 1, ],
+    type = type_barplot(offset = 10))
+}
+expect_snapshot_plot(f, label = "barplot_offset_scalar")
+
+# Vector offset (waterfall pattern)
+f = function() {
+  d = data.frame(x = factor(LETTERS[1:4]), y = c(10, 5, -3, 8))
+  d$off = c(0, cumsum(d$y[-4]))
+  tinyplot(y ~ x, data = d, type = type_barplot(offset = d$off))
+}
+expect_snapshot_plot(f, label = "barplot_offset_waterfall")
+
+# Offset + beside with grouping
+f = function() {
+  tinyplot(extra ~ ID | group, data = sleep,
+    type = type_barplot(beside = TRUE, offset = rep(1, 10)))
+}
+expect_snapshot_plot(f, label = "barplot_offset_beside_group")
+
+# Offset + stacked
+f = function() {
+  tinyplot(Freq ~ Sex | Survived, data = as.data.frame(Titanic)[1:8, ],
+    type = type_barplot(offset = c(10, 20)))
+}
+expect_snapshot_plot(f, label = "barplot_offset_stacked")
+
+# Offset + flip
+f = function() {
+  d = data.frame(x = factor(LETTERS[1:3]), y = c(5, 3, 7))
+  tinyplot(y ~ x, data = d, type = type_barplot(offset = c(2, 4, 1)), flip = TRUE)
+}
+expect_snapshot_plot(f, label = "barplot_offset_flip")
+
+# Offset + center warns and ignores center
+expect_warning(
+  tinyplot(~ cyl | vs, data = mtcars,
+    type = type_barplot(offset = c(5, 10, 15), center = TRUE)),
+  "cannot be combined"
+)
+
+# Wrong offset length errors
+expect_error(
+  tinyplot(~ cyl, data = mtcars, type = type_barplot(offset = c(1, 2))),
+  "must be length"
+)

--- a/man/type_barplot.Rd
+++ b/man/type_barplot.Rd
@@ -94,7 +94,7 @@ tinyplot(Freq ~ Eye | Hair, facet = ~ Sex, data = hec, type = "barplot",
 
 tinytheme()
 
-# Manualy waterfall plot example using offset
+# Manual waterfall plot example using offset
 d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
                value = c(100, 40, -80, -10, 60))
 d$item = factor(d$item, levels = d$item)

--- a/man/type_barplot.Rd
+++ b/man/type_barplot.Rd
@@ -96,7 +96,7 @@ tinytheme()
 
 # Manual waterfall plot example using offset
 d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
-               value = c(100, 40, -80, -10, 60))
+               value = c(100, 40, -80, -10, 50))
 d$item = factor(d$item, levels = d$item)
 d$offset = c(0, cumsum(d$value[1:3]), 0)
 tinyplot(value ~ item | I(value < 0), data = d,

--- a/man/type_barplot.Rd
+++ b/man/type_barplot.Rd
@@ -8,6 +8,7 @@ type_barplot(
   width = 5/6,
   beside = FALSE,
   center = FALSE,
+  offset = NULL,
   FUN = NULL,
   xlevels = NULL,
   xaxlabels = NULL,
@@ -28,6 +29,12 @@ uneven number of categories) or between the two middle categories (in case
 of an even number). Additionally it is possible to set \code{center = 2} or
 \code{center = 2.5} to indicate that centering should be after the second category
 or the mid-way in the third category, respectively.}
+
+\item{offset}{numeric. Optional vertical offset(s) for bar baselines. When
+provided, bars start at the offset value(s) rather than zero. Accepts
+either a single scalar (applied to all bars) or a numeric vector with one
+value per x-level (matched after any \code{xlevels} reordering).
+Cannot be combined with \code{center}.}
 
 \item{FUN}{a function to compute the summary statistic for \code{y} within each
 group of \code{x} in case of using a two-sided formula \code{y ~ x} (default: mean).}
@@ -86,5 +93,14 @@ tinyplot(Freq ~ Eye | Hair, facet = ~ Sex, data = hec, type = "barplot",
   center = TRUE, flip = TRUE, facet.args = list(ncol = 1), yaxl = "percent")
 
 tinytheme()
+
+# Manualy waterfall plot example using offset
+d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
+               value = c(100, 40, -80, -10, 60))
+d$item = factor(d$item, levels = d$item)
+d$offset = c(0, cumsum(d$value[1:3]), 0)
+tinyplot(value ~ item | I(value < 0), data = d,
+  type = type_barplot(offset = d$offset), legend = FALSE)
+tinyplot_add(type = type_vline(4.5), lty = 2)
 
 }


### PR DESCRIPTION
Needed this for work today.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot

tinyplot(extra ~ ID, data = sleep[sleep$group == 1, ],
  type = type_barplot(offset = 10))
```

![](https://i.imgur.com/yE2zOUL.png)<!-- -->

``` r

# waterfall chart

d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
               value = c(100, 40, -80, -10, 50))
d$item = factor(d$item, levels = d$item)
d$offset = c(0, cumsum(d$value[1:3]), 0)
tinyplot(value ~ item | I(value < 0), data = d,
  type = type_barplot(offset = d$offset), legend = FALSE)
tinyplot_add(type = type_vline(4.5), lty = 2)
```

![](https://i.imgur.com/eIXLE3L.png)<!-- -->

<sup>Created on 2026-06-05 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

HU @zeileis (one step towards #420)