### PR TITLE
Barplots: Likert-style category offsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -144,8 +144,15 @@ Theme fixes:
   `plt(..., facet = 1 ~ z)` can be used as a shortcut for
   `plt(..., facet = ~ z, facet.args = list(nrow = 1))`. (#562 @zeileis)
 - `type_barplot()` gains an `offset` argument for shifting bar baselines away
-  from zero. Accepts a scalar or per-x-level numeric vector. Useful for
-  waterfall plots and floating bars. (#611 @grantmcdermott)
+  from zero. (#611, #615 @grantmcdermott @zeileis)
+  - If the offset is an unnamed scalar or numeric vector, it shifts the bars
+    positionally by the given values. Useful for creating waterfall plots and
+    floating bars.
+  - If the offset is a character or named numeric vector, it instead "sets
+    aside" the named level(s) of the `by` group, pulling them out of the stack
+    and drawing them as standalone bars. This is useful for Likert plots, where
+    you want to show a neutral categories (e.g., "Unsure") apart from the 
+    diverging stack. Thanks to @strengejacke for the suggestion.
 
 ### Bug fixes
 

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -24,11 +24,20 @@
 #'   (if numeric) for the plot.
 #' @param xaxlabels a character vector with the axis labels for the `x` variable,
 #'   defaulting to the levels of `x`.
-#' @param offset numeric. Optional vertical offset(s) for bar baselines. When
-#'   provided, bars start at the offset value(s) rather than zero. Accepts
-#'   either a single scalar (applied to all bars) or a numeric vector with one
-#'   value per x-level (matched after any `xlevels` reordering).
-#'   Cannot be combined with `center`.
+#' @param offset optional specification for shifting bar baselines, accepting
+#'   one of two distinct forms. See the Examples for illustrations of both.
+#' 
+#'   - *Positions* via an unnamed numeric scalar or vector. Bars start at the
+#'   offset value(s) rather than zero, matched per x-level after any `xlevels`
+#'   reordering (a scalar is applied to all bars). Useful for waterfall charts.
+#'   The positional form cannot be combined with `center`.
+#'   - *Category* via a character vector such as `offset = "Unsure"`, or a
+#'   named numeric vector such as `offset = c(Unsure = 1.1)`. The named
+#'   level(s) of the `by` grouping are "set aside", i.e. pulled out of the
+#'   (optionally centered) stack and drawn as standalone bars. This is useful
+#'   for diverging/Likert plots where a neutral category (e.g. "Unsure") is
+#'   shown apart from the diverging stack. The category form requires a `by`
+#'   grouping and `beside = FALSE`, but can be combined with `center`.
 #' @param drop.zeros logical. Should bars with zero height be dropped? If set
 #'   to `FALSE` (default) a zero height bar is still drawn for which the border
 #'   lines will still be visible.
@@ -69,8 +78,10 @@
 #'   center = TRUE, flip = TRUE, facet.args = list(ncol = 1), yaxl = "percent")
 #'
 #' tinytheme()
+#' 
+#' # Use cases for the `offset` argument
 #'
-#' # Manual waterfall plot example using offset
+#' # 1. Waterfall plot
 #' d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
 #'                value = c(100, 40, -80, -10, 50))
 #' d$item = factor(d$item, levels = d$item)
@@ -78,6 +89,34 @@
 #' tinyplot(value ~ item | I(value < 0), data = d,
 #'   type = type_barplot(offset = d$offset), legend = FALSE)
 #' tinyplot_add(type = type_vline(4.5), lty = 2)
+#'
+#' # 2. Diverging/Likert layout: a character (or named numeric) offset "sets
+#' # aside" the named category, pulling it out of the centered stack and drawing
+#' # it as a standalone bar. Here a neutral "Unsure" response is shown apart from
+#' # the diverging agree/disagree scale.
+#' lik = expand.grid(
+#'   question = c("Pay", "Workload", "Manager", "Culture"),
+#'   response = c("Strong disagree", "Disagree", "Agree", "Strong agree", "Unsure")
+#' )
+#' lik$response = factor(lik$response, levels = unique(lik$response))
+#' lik$share = c( # proportions summing to 1 within each question
+#'   .10, .25, .05, .15,
+#'   .20, .30, .15, .20,
+#'   .35, .20, .40, .30,
+#'   .25, .15, .35, .20,
+#'   .10, .10, .05, .15
+#' )
+#' # diverging palette: reds (disagree) -> blues (agree), grey for "Unsure"
+#' pal = c("#b2182b", "#ef8a62", "#67a9cf", "#2166ac", "grey")
+#' tinyplot(
+#'   share ~ question | response, data = lik,
+#'   type = "barplot", center = TRUE, offset = "Unsure",
+#'   flip = TRUE, xlab = NA, ylab = NA, yaxl = "percent",
+#'   legend = list("top!", title = NULL),
+#'   theme = list("clean2", palette.qualitative = pal),
+#'   main = "Hypothetical Likert example with category offset"
+#' )
+#' tinyplot_add(type = "vline")
 #'
 #' @export
 type_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NULL, FUN = NULL, xlevels = NULL, xaxlabels = NULL, drop.zeros = FALSE) {
@@ -125,23 +164,63 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NU
         if (!is.factor(datapoints$by)) datapoints$by = factor(datapoints$by)
         if (!is.factor(datapoints$facet)) datapoints$facet = factor(datapoints$facet)
         
+        ## `offset` accepts two distinct forms:
+        ##  - unnamed numeric -> positional, keyed by x-level (waterfall)
+        ##  - character or *named* numeric -> keyed by `by`-level: those groups
+        ##    are "set aside", i.e. pulled out of the (optionally centered) stack
+        ##    and drawn as standalone bars (diverging/Likert layout).
+        aside = NULL # named numeric of set-aside `by`-levels -> baseline value
         if (!is.null(offset)) {
-          if (!is.numeric(offset)) stop("'offset' must be numeric")
-          if (!isFALSE(center)) {
-            warning("'offset' cannot be combined with 'center'; ignoring 'center'")
-            center = FALSE
-          }
-          nx_levels = nlevels(datapoints$x)
-          if (length(offset) == 1L) {
-            offset = rep(offset, nx_levels)
-          } else if (length(offset) != nx_levels) {
-            stop(sprintf(
-              "'offset' must be length 1 or %d (number of x levels), got %d",
-              nx_levels, length(offset)
-            ))
+          offset_bylevel = is.character(offset) ||
+            (is.numeric(offset) && !is.null(names(offset)) && any(nzchar(names(offset))))
+          if (offset_bylevel) {
+            if (isTRUE(null_by)) {
+              stop("a character or named 'offset' requires a 'by' grouping variable")
+            }
+            if (isTRUE(facet_by)) {
+              stop("a character or named 'offset' is not supported when 'facet' is the 'by' grouping")
+            }
+            if (beside) {
+              stop("a character or named 'offset' requires stacked bars; set 'beside = FALSE'")
+            }
+            nm = if (is.character(offset)) offset else names(offset)
+            bad = setdiff(nm, levels(datapoints$by))
+            if (length(bad)) {
+              stop(sprintf(
+                "'offset' must name levels of the 'by' grouping; unknown: %s",
+                paste(bad, collapse = ", ")
+              ))
+            }
+            if (is.character(offset)) {
+              ## auto-placement: baseline = max full-column total (incl. set-aside)
+              col_tot = tapply(
+                datapoints$y, interaction(datapoints$x, datapoints$facet),
+                sum, na.rm = TRUE
+              )
+              base_auto = max(col_tot, na.rm = TRUE)
+              aside = stats::setNames(rep(base_auto, length(offset)), offset)
+            } else {
+              aside = offset
+            }
+            offset = NULL # disable the positional post-hoc shift below
+          } else {
+            if (!is.numeric(offset)) stop("'offset' must be numeric")
+            if (!isFALSE(center)) {
+              warning("'offset' cannot be combined with 'center'; ignoring 'center'")
+              center = FALSE
+            }
+            nx_levels = nlevels(datapoints$x)
+            if (length(offset) == 1L) {
+              offset = rep(offset, nx_levels)
+            } else if (length(offset) != nx_levels) {
+              stop(sprintf(
+                "'offset' must be length 1 or %d (number of x levels), got %d",
+                nx_levels, length(offset)
+              ))
+            }
           }
         }
-        if (is.null(offset) && isFALSE(null_by) && isFALSE(facet_by) && !beside && any(datapoints$y < 0)) {
+        if (is.null(offset) && is.null(aside) && isFALSE(null_by) && isFALSE(facet_by) && !beside && any(datapoints$y < 0)) {
           warning("'beside' must be TRUE if there are negative 'y' values")
           beside = TRUE
         }
@@ -160,11 +239,30 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NU
         if (is.null(ylim)) ylim = if (beside || length(unique(datapoints$by)) == 1L) {
           c(pmin(0, min(datapoints$y, na.rm = TRUE) * 1.02), pmax(0, max(datapoints$y, na.rm = TRUE) * 1.02))
         } else {
-          range(unlist(tapply(
-            datapoints$y,
+          is_off = if (is.null(aside)) rep(FALSE, nrow(datapoints)) else datapoints$by %in% names(aside)
+          ## range of the centered/stacked retained (non-set-aside) categories
+          stack_range = range(unlist(tapply(
+            seq_len(nrow(datapoints)),
             interaction(datapoints$x, datapoints$facet),
-            function(z) c(0, sum(z, na.rm = TRUE)) - offset_sum(z, center = center)
-          ))) * 1.02
+            function(idx) {
+              z = datapoints$y[idx]
+              keep = !is_off[idx]
+              zc = z; zc[!keep] = 0
+              c(0, sum(zc, na.rm = TRUE)) - offset_sum(z[keep], center = center)
+            }
+          )))
+          ## range of the standalone set-aside bars (stacked from their baselines)
+          off_range = NULL
+          if (any(is_off)) {
+            base = aside[as.character(datapoints$by[is_off])]
+            ytop = unlist(tapply(
+              seq_len(sum(is_off)),
+              interaction(datapoints$x[is_off], datapoints$facet[is_off]),
+              function(j) base[j] + cumsum(datapoints$y[is_off][j])
+            ))
+            off_range = range(c(base, ytop), na.rm = TRUE)
+          }
+          range(c(stack_range, off_range), na.rm = TRUE) * 1.02
         }
 
         ## default color palette
@@ -190,11 +288,32 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, offset = NU
             yb = 0
             yt = df$y
           } else {
-            cs = tapply(df$y, df$x, function(z) cumsum(c(0, z)) - offset_sum(z, center = center))
+            is_off = if (is.null(aside)) rep(FALSE, nrow(df)) else df$by %in% names(aside)
             xl = as.numeric(df$x) - width/2
             xr = xl + width
+            ## stack/center only the retained categories: set-aside rows are
+            ## zeroed so they don't grow or shift the centered stack, but the
+            ## centering midpoint is computed from the retained subset alone.
+            cs = tapply(seq_len(nrow(df)), df$x, function(idx) {
+              z = df$y[idx]
+              keep = !is_off[idx]
+              zc = z; zc[!keep] = 0
+              cumsum(c(0, zc)) - offset_sum(z[keep], center = center)
+            })
             yb = if (facet_by) 0 else unlist(lapply(cs, `[`, -(nb + 1L)))
             yt = if (facet_by) df$y else unlist(lapply(cs, `[`, -1L))
+            ## set-aside rows: standalone bars stacked from their baseline value
+            if (any(is_off)) {
+              base = aside[as.character(df$by[is_off])]
+              ot = unlist(tapply(
+                seq_len(sum(is_off)),
+                df$x[is_off],
+                function(j) base[j] + cumsum(df$y[is_off][j])
+              ))
+              ob = ot - df$y[is_off]
+              yb[is_off] = ob
+              yt[is_off] = ot
+            }
           }
           
           df$xmin = xl

--- a/inst/tinytest/_tinysnapshot/barplot_offset_aside.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_aside.svg
@@ -1,0 +1,129 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='443.97' y='218.43' width='16.75' height='16.75' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='443.97' y='236.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='443.97' y='254.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='443.97' y='272.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<text x='446.94' y='207.00' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Hair</text>
+<text x='463.14' y='230.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='29.34px' lengthAdjust='spacingAndGlyphs'>Black</text>
+<text x='463.14' y='248.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text x='463.14' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Red</text>
+<text x='463.14' y='284.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Blond</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MjcuMTR8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='427.14' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MjcuMTR8MC4wMHw1MDQuMDA=)'>
+<text x='243.09' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.67px' lengthAdjust='spacingAndGlyphs'>Freq</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>Eye</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng=='>
+    <rect x='59.04' y='59.04' width='368.10' height='169.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text transform='translate(41.76,205.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text transform='translate(41.76,164.52) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>Blue</text>
+<text transform='translate(41.76,123.48) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Hazel</text>
+<rect x='59.04' y='43.20' width='368.10' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='243.09' y='55.25' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.02px' lengthAdjust='spacingAndGlyphs'>Male</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY='>
+    <rect x='59.04' y='260.64' width='368.10' height='169.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='80.60' y1='430.56' x2='377.58' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='80.60' y1='430.56' x2='80.60' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='179.59' y1='430.56' x2='179.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='278.59' y1='430.56' x2='278.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='377.58' y1='430.56' x2='377.58' y2='437.76' style='stroke-width: 0.75;' />
+<text x='80.60' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>50%</text>
+<text x='179.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='17.34px' lengthAdjust='spacingAndGlyphs'>0%</text>
+<text x='278.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>50%</text>
+<text x='377.58' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>100%</text>
+<text transform='translate(41.76,407.17) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text transform='translate(41.76,366.12) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>Blue</text>
+<text transform='translate(41.76,325.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Hazel</text>
+<rect x='59.04' y='244.80' width='368.10' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='243.09' y='256.85' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>Female</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng==)'>
+<rect x='61.40' y='188.46' width='64.65' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='109.02' y='147.42' width='21.56' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='84.81' y='106.38' width='42.13' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='116.60' y='65.33' width='18.00' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='126.05' y='188.46' width='107.08' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='130.58' y='147.42' width='98.02' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='126.93' y='106.38' width='105.31' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='134.59' y='65.33' width='90.00' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='377.58' y='188.46' width='20.20' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='147.42' width='19.60' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='106.38' width='29.49' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='65.33' width='42.00' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='233.13' y='188.46' width='6.06' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='228.60' y='147.42' width='58.81' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='232.25' y='106.38' width='21.06' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='224.59' y='65.33' width='48.00' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+</g>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY=)'>
+<rect x='67.61' y='390.06' width='58.42' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='134.44' y='349.02' width='15.63' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='95.66' y='307.98' width='21.52' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='122.11' y='266.93' width='12.77' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='126.04' y='390.06' width='107.11' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='150.07' y='349.02' width='59.05' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='117.18' y='307.98' width='124.82' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='134.88' y='266.93' width='89.42' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='377.58' y='390.06' width='25.97' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='349.02' width='12.16' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='307.98' width='30.13' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='377.58' y='266.93' width='44.71' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='233.15' y='390.06' width='6.49' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='209.12' y='349.02' width='111.15' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='242.00' y='307.98' width='21.52' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='224.30' y='266.93' width='51.09' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+</g>
+<defs>
+  <clipPath id='cpMTA5LjQ0fDQwNS41NHw5NS4wNHwzNjUuNzY='>
+    <rect x='109.44' y='95.04' width='296.10' height='270.72' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA5LjQ0fDQwNS41NHw5NS4wNHwzNjUuNzY=)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/barplot_offset_aside_explicit.svg
+++ b/inst/tinytest/_tinysnapshot/barplot_offset_aside_explicit.svg
@@ -1,0 +1,129 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='443.97' y='218.43' width='16.75' height='16.75' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='443.97' y='236.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='443.97' y='254.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='443.97' y='272.43' width='16.75' height='16.75' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<text x='446.94' y='207.00' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Hair</text>
+<text x='463.14' y='230.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='29.34px' lengthAdjust='spacingAndGlyphs'>Black</text>
+<text x='463.14' y='248.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text x='463.14' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Red</text>
+<text x='463.14' y='284.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Blond</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MjcuMTR8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='427.14' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MjcuMTR8MC4wMHw1MDQuMDA=)'>
+<text x='243.09' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.67px' lengthAdjust='spacingAndGlyphs'>Freq</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>Eye</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng=='>
+    <rect x='59.04' y='59.04' width='368.10' height='169.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text transform='translate(41.76,205.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text transform='translate(41.76,164.52) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>Blue</text>
+<text transform='translate(41.76,123.48) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Hazel</text>
+<rect x='59.04' y='43.20' width='368.10' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='243.09' y='55.25' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='26.02px' lengthAdjust='spacingAndGlyphs'>Male</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY='>
+    <rect x='59.04' y='260.64' width='368.10' height='169.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='79.48' y1='430.56' x2='361.02' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='79.48' y1='430.56' x2='79.48' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='173.32' y1='430.56' x2='173.32' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='267.17' y1='430.56' x2='267.17' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='361.02' y1='430.56' x2='361.02' y2='437.76' style='stroke-width: 0.75;' />
+<text x='79.48' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>50%</text>
+<text x='173.32' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='17.34px' lengthAdjust='spacingAndGlyphs'>0%</text>
+<text x='267.17' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>50%</text>
+<text x='361.02' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>100%</text>
+<text transform='translate(41.76,407.17) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='34.02px' lengthAdjust='spacingAndGlyphs'>Brown</text>
+<text transform='translate(41.76,366.12) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>Blue</text>
+<text transform='translate(41.76,325.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>Hazel</text>
+<rect x='59.04' y='244.80' width='368.10' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='243.09' y='256.85' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>Female</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDU5LjA0fDIyOC45Ng==)'>
+<rect x='61.28' y='188.46' width='61.29' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='106.42' y='147.42' width='20.44' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='83.47' y='106.38' width='39.93' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='113.60' y='65.33' width='17.06' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='122.57' y='188.46' width='101.51' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='126.86' y='147.42' width='92.92' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='123.40' y='106.38' width='99.84' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='130.66' y='65.33' width='85.32' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='379.79' y='188.46' width='19.15' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='147.42' width='18.58' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='106.38' width='27.95' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='65.33' width='39.81' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='224.08' y='188.46' width='5.75' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='219.78' y='147.42' width='55.75' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='223.24' y='106.38' width='19.97' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='215.98' y='65.33' width='45.50' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+</g>
+<g clip-path='url(#cpNTkuMDR8NDI3LjE0fDI2MC42NHw0MzAuNTY=)'>
+<rect x='67.17' y='390.06' width='55.38' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='130.52' y='349.02' width='14.82' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='93.76' y='307.98' width='20.40' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='118.83' y='266.93' width='12.11' height='34.20' style='stroke-width: 0.75; fill: #000000;' />
+<rect x='122.55' y='390.06' width='101.54' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='145.33' y='349.02' width='55.98' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='114.16' y='307.98' width='118.33' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='130.94' y='266.93' width='84.76' height='34.20' style='stroke-width: 0.75; stroke: #DF536B; fill: #DF536B;' />
+<rect x='379.79' y='390.06' width='24.62' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='349.02' width='11.53' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='307.98' width='28.56' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='379.79' y='266.93' width='42.38' height='34.20' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
+<rect x='224.09' y='390.06' width='6.15' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='201.31' y='349.02' width='105.37' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='232.49' y='307.98' width='20.40' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+<rect x='215.70' y='266.93' width='48.44' height='34.20' style='stroke-width: 0.75; stroke: #2297E6; fill: #2297E6;' />
+</g>
+<defs>
+  <clipPath id='cpMTA5LjQ0fDQwNS41NHw5NS4wNHwzNjUuNzY='>
+    <rect x='109.44' y='95.04' width='296.10' height='270.72' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA5LjQ0fDQwNS41NHw5NS4wNHwzNjUuNzY=)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-type_barplot.R
+++ b/inst/tinytest/test-type_barplot.R
@@ -140,3 +140,38 @@ expect_error(
   tinyplot(~ cyl, data = mtcars, type = type_barplot(offset = c(1, 2))),
   "must be length"
 )
+
+
+#
+## by-level offset ("set aside" / diverging-Likert)
+
+hec = as.data.frame(proportions(HairEyeColor, 2:3))
+
+# Character offset auto-places a set-aside category (the #420 use case)
+f = function() {
+  tinyplot(Freq ~ Eye | Hair, facet = Sex ~ 1, data = hec, type = "barplot",
+    center = TRUE, flip = TRUE, yaxl = "percent", offset = "Red")
+}
+expect_snapshot_plot(f, label = "barplot_offset_aside")
+
+# Named numeric offset places a set-aside category at an explicit baseline
+f = function() {
+  tinyplot(Freq ~ Eye | Hair, facet = Sex ~ 1, data = hec, type = "barplot",
+    center = TRUE, flip = TRUE, yaxl = "percent", offset = c(Red = 1.1))
+}
+expect_snapshot_plot(f, label = "barplot_offset_aside_explicit")
+
+# Invalid by-level offsets error
+expect_error( # unknown level
+  tinyplot(~ cyl | vs, data = mtcars, type = type_barplot(offset = "nope")),
+  "must name levels"
+)
+expect_error( # no `by` grouping
+  tinyplot(~ cyl, data = mtcars, type = type_barplot(offset = "4")),
+  "requires a 'by' grouping"
+)
+expect_error( # requires stacked bars
+  tinyplot(~ cyl | vs, data = mtcars,
+    type = type_barplot(offset = "0", beside = TRUE)),
+  "requires stacked bars"
+)

--- a/man/type_barplot.Rd
+++ b/man/type_barplot.Rd
@@ -30,11 +30,21 @@ of an even number). Additionally it is possible to set \code{center = 2} or
 \code{center = 2.5} to indicate that centering should be after the second category
 or the mid-way in the third category, respectively.}
 
-\item{offset}{numeric. Optional vertical offset(s) for bar baselines. When
-provided, bars start at the offset value(s) rather than zero. Accepts
-either a single scalar (applied to all bars) or a numeric vector with one
-value per x-level (matched after any \code{xlevels} reordering).
-Cannot be combined with \code{center}.}
+\item{offset}{optional specification for shifting bar baselines, accepting
+one of two distinct forms. See the Examples for illustrations of both.
+\itemize{
+\item \emph{Positions} via an unnamed numeric scalar or vector. Bars start at the
+offset value(s) rather than zero, matched per x-level after any \code{xlevels}
+reordering (a scalar is applied to all bars). Useful for waterfall charts.
+The positional form cannot be combined with \code{center}.
+\item \emph{Category} via a character vector such as \code{offset = "Unsure"}, or a
+named numeric vector such as \code{offset = c(Unsure = 1.1)}. The named
+level(s) of the \code{by} grouping are "set aside", i.e. pulled out of the
+(optionally centered) stack and drawn as standalone bars. This is useful
+for diverging/Likert plots where a neutral category (e.g. "Unsure") is
+shown apart from the diverging stack. The category form requires a \code{by}
+grouping and \code{beside = FALSE}, but can be combined with \code{center}.
+}}
 
 \item{FUN}{a function to compute the summary statistic for \code{y} within each
 group of \code{x} in case of using a two-sided formula \code{y ~ x} (default: mean).}
@@ -94,7 +104,9 @@ tinyplot(Freq ~ Eye | Hair, facet = ~ Sex, data = hec, type = "barplot",
 
 tinytheme()
 
-# Manual waterfall plot example using offset
+# Use cases for the `offset` argument
+
+# 1. Waterfall plot
 d = data.frame(item = c("Sales", "Services", "Costs", "Returns", "TOTAL"),
                value = c(100, 40, -80, -10, 50))
 d$item = factor(d$item, levels = d$item)
@@ -102,5 +114,30 @@ d$offset = c(0, cumsum(d$value[1:3]), 0)
 tinyplot(value ~ item | I(value < 0), data = d,
   type = type_barplot(offset = d$offset), legend = FALSE)
 tinyplot_add(type = type_vline(4.5), lty = 2)
+
+# 2. Diverging/Likert layout: a character (or named numeric) offset "sets
+# aside" the named category, pulling it out of the centered stack and drawing
+# it as a standalone bar. Here a neutral "Unsure" response is shown apart from
+# the diverging agree/disagree scale.
+lik = expand.grid(
+  question = c("Pay", "Workload", "Manager", "Culture"),
+  response = c("Strong disagree", "Disagree", "Agree", "Strong agree", "Unsure")
+)
+lik$response = factor(lik$response, levels = unique(lik$response))
+lik$share = c( # proportions summing to 1 within each question
+  .10, .25, .05, .15,   .20, .30, .15, .20,   .35, .20, .40, .30,
+  .25, .15, .35, .20,   .10, .10, .05, .15
+)
+# diverging palette: reds (disagree) -> blues (agree), grey for "Unsure"
+pal = c("#b2182b", "#ef8a62", "#67a9cf", "#2166ac", "grey")
+tinyplot(
+  share ~ question | response, data = lik,
+  type = "barplot", center = TRUE, offset = "Unsure",
+  flip = TRUE, xlab = NA, ylab = NA, yaxl = "percent",
+  legend = list("top!", title = NULL),
+  theme = list("clean2", palette.qualitative = pal),
+  main = "Hypothetical Likert example with category offset"
+)
+tinyplot_add(type = "vline")
 
 }


### PR DESCRIPTION
Closes #420

It's a pretty simple API: The idea is that you pass the relevant `by` category that you want to set apart (e.g., `"Unsure"`) to `offset` and we automatically calculate spacing, etc. for you.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
# Employee survey: 4 questions, diverging Likert responses + an "Unsure" category
lik = expand.grid(
  question = c("Pay", "Workload", "Manager", "Culture"),
  response = c("Strong disagree", "Disagree", "Agree", "Strong agree", "Unsure")
)
# proportions that sum to 1 within each question
m = matrix(c(
  .10, .20, .35, .25, .10,   # Pay
  .25, .30, .20, .15, .10,   # Workload
  .05, .15, .40, .35, .05,   # Manager
  .15, .20, .30, .20, .15    # Culture
), nrow = 4, byrow = TRUE)
lik$share = as.vector(m)

# plot
tinyplot(
  share ~ question | response, data = lik,
  type = "barplot", center = TRUE, offset = "Unsure",
  # type = type_barplot(center = TRUE, offset = "Unsure"), ## same
  flip = TRUE
)
```

![](https://i.imgur.com/J8OeGhD.png)<!-- -->

Fancier version with a diverging palette and nicer, themed aesthetic.

``` r
pal = c("#b2182b", "#ef8a62", "#67a9cf", "#2166ac", "grey")
tinyplot(
  share ~ question | response, data = lik,
  type = "barplot", center = TRUE, offset = "Unsure",
  flip = TRUE,
  xlab = NA, ylab = NA, yaxl = "percent",
  legend = list("top!", title = NULL),
  theme = list("ipsum", palette.qualitative = pal),
  main = "Likert example with category offset",
  sub = "Workplace satisfaction",
  cap = 'Question: "I am satisified with <feature> at my work."'
)
plt_add(type = 'vline')
```

![](https://i.imgur.com/C9iCoBH.png)<!-- -->

<sup>Created on 2026-06-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

HU @zeileis and @strengejacke (original suggestion on BlueSky IIRC). **Edit:** Found it: https://bsky.app/profile/strengejacke.de/post/3lqrkrccmgc2p