### PR TITLE
repel text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -153,10 +153,13 @@ Theme fixes:
     and drawing them as standalone bars. This is useful for Likert plots, where
     you want to show a neutral categories (e.g., "Unsure") apart from the 
     diverging stack. Thanks to @strengejacke for the suggestion.
-- `type_text()` (and `type = "text"`) gains a `labeller` argument that is passed
-  to `tinylabel()` for formatting the text labels. This is useful for ensuring
-  that text annotations match a formatted axis, e.g. `labeller = "%"` to display
-  the labels as percentages. (#620 @grantmcdermott)
+- `type_text()` gains two new arguments:
+  - a `labeller` argument that is passed to `tinylabel()` for formatting the
+    text labels. (#620 @grantmcdermott)
+  - a `repel` argument that automatically nudges overlapping text labels apart.
+    One limitation is that the repulsion logic operates with groups. So there
+    may still be some overlapping text for for grouped data.
+    (#621 @grantmcdermott)
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -187,7 +187,7 @@ Theme fixes:
   `"$0.50"` rather than `"$0.5"`), while still keeping clean integers
   integer-valued (e.g. `"$1,000"`), and place the negative sign in front of the
   currency symbol (e.g. `"-$1.50"` rather than `"$-1.50"`).
-  (#618 @grantmcdermott)
+  (#618, #623 @grantmcdermott)
 
 ## v0.6.1
 

--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -195,5 +195,19 @@ labeller_fun = function(label = "percent") {
   )
 
   ## combine with absolute value if necessary
-  if (abs_) function(x) fun(abs(x)) else fun
+  numeric_fun = if (abs_) function(x) fun(abs(x)) else fun
+
+  # The built-in formatters coerce their input via as.numeric(). Guard against
+  # non-numeric input (e.g. categorical axis labels reaching a numeric labeller
+  # via flip = TRUE) by leaving such values unchanged, which avoids "NAs
+  # introduced by coercion" warnings (#622). The is.na(xn) & !is.na(x) test only
+  # flags values that became NA through coercion, so genuine NA input still
+  # reaches the formatter.
+  function(x) {
+    xn = suppressWarnings(as.numeric(x))
+    if (any(is.na(xn) & !is.na(x))) {
+      return(x)
+    }
+    numeric_fun(x)
+  }
 }

--- a/R/type_text.R
+++ b/R/type_text.R
@@ -21,6 +21,16 @@
 #' @param xpd Logical value or `NA` denoting text clipping behaviour, following
 #'  \code{\link[graphics]{par}}.
 #' @param srt Numeric giving the desired string rotation in degrees.
+#' @param repel Logical or numeric controlling automatic repulsion of
+#'   overlapping text labels. The default `FALSE` draws the labels at their
+#'   exact (`x`,`y`) coordinates. `TRUE` nudges overlapping labels apart using a
+#'   force-directed algorithm (labels are pushed off each other and then sprung
+#'   back toward their original positions). A numeric value does the same but
+#'   additionally enforces that much minimum padding (in user coordinates)
+#'   between labels. Works best with the default centered text placement (i.e.
+#'   without `pos`). **Caveat:** The repulsion logic currently operates
+#'   within each group rather than across groups. So the text of different
+#'   groups may still overlap. See Examples.
 #' @param clim Numeric giving the lower and upper limits of the character
 #'   expansion (`cex`) normalization for bubble charts.
 #' @inheritParams graphics::text
@@ -30,10 +40,19 @@
 #'
 #' # pass explicit `labels` arg if you want specific text
 #' tinyplot(1:12, type = "text", labels = month.abb)
+#' 
+#' # you can also use a labeller function (passed to `tinylabel`) to
+#' # customize
+#' tinyplot(1:12, type = "text", labels = month.abb, labeller = toupper)
 #'
 #' # for advanced customization, it's safer to pass args through `type_text()`
-#' tinyplot(1:12, type = type_text(
-#'   labels = month.abb, family = "HersheyScript", srt = -20))
+#' tinyplot(
+#'   1:12,
+#'   type = type_text(
+#'   labels = month.abb,
+#'   family = "HersheyScript",
+#'   srt = -20)
+#' )
 #'
 #' # same principles apply to grouped and/or facet data
 #' tinyplot(mpg ~ hp | factor(cyl),
@@ -58,10 +77,18 @@
 #'   )
 #' )
 #'
-#' # use `labeller` to format the labels, e.g. to match a formatted axis
-#' d = data.frame(x = c("A", "B"), y = c(0.5, 0.8))
-#' tinyplot(y ~ x, data = d, type = "bar", ylim = c(0, 1), yaxl = "%")
-#' tinyplot_add(type = type_text(labeller = "%", adj = c(0.5, -0.5)))
+#' # use `repel = TRUE` to automically nudge overlapping labels apart
+#' tinyplot(
+#'   mpg ~ wt, data = mtcars,
+#'   type = type_text(labels = row.names(mtcars), repel = TRUE)
+#' )
+#' 
+#' # limitation: `repel` logic currently works per group, so grouped text data
+#' # may still overlap
+#' tinyplot(
+#'   mpg ~ wt | factor(cyl), data = mtcars,
+#'   type = type_text(labels = row.names(mtcars), repel = TRUE)
+#' )
 #'
 #' @export
 type_text = function(
@@ -75,6 +102,7 @@ type_text = function(
   vfont = NULL,
   xpd = NULL,
   srt = 0,
+  repel = FALSE,
   clim = c(0.5, 2.5)
 ) {
   out = list(
@@ -86,7 +114,8 @@ type_text = function(
       family = family,
       font = font,
       xpd = xpd,
-      srt = srt
+      srt = srt,
+      repel = repel
     ),
     data = data_text(labels = labels, labeller = labeller, clim = clim),
     name = "text"
@@ -133,7 +162,8 @@ draw_text = function(
   family = NULL,
   font = NULL,
   xpd = NULL,
-  srt = 0
+  srt = 0,
+  repel = FALSE
 ) {
   if (is.null(xpd)) {
     xpd = par("xpd")
@@ -142,6 +172,20 @@ draw_text = function(
     vfont = NULL
   }
   fun = function(ix, iy, ilabels, icol, icex, ...) {
+    # Optionally repel overlapping labels. Measurement requires user
+    # coordinates, which are only correct here (post `plot.window()`), not in
+    # the type's data function. See `repel_text()` in R/repel.R.
+    if (!isFALSE(repel) && length(ix) > 1) {
+      min_gap = if (isTRUE(repel)) 0 else as.numeric(repel)
+      w = strwidth(ilabels, units = "user", cex = icex, font = font, family = family)
+      h = strheight(ilabels, units = "user", cex = icex, font = font, family = family)
+      rp = repel_text(
+        x = ix, y = iy, widths = w, heights = h,
+        min_gap = min_gap, axis = "both"
+      )
+      ix = rp[["x"]]
+      iy = rp[["y"]]
+    }
     text(
       x = ix,
       y = iy,

--- a/inst/tinytest/_tinysnapshot/text_repel.svg
+++ b/inst/tinytest/_tinysnapshot/text_repel.svg
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='34.47' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='89.97px' lengthAdjust='spacingAndGlyphs'>repel = TRUE</text>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<line x1='122.22' y1='430.56' x2='416.77' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='122.22' y1='430.56' x2='122.22' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='220.40' y1='430.56' x2='220.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='318.59' y1='430.56' x2='318.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='416.77' y1='430.56' x2='416.77' y2='437.76' style='stroke-width: 0.75;' />
+<text x='122.22' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='220.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='318.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='416.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='422.66' x2='59.04' y2='129.89' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='422.66' x2='51.84' y2='422.66' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='349.46' x2='51.84' y2='349.46' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='276.27' x2='51.84' y2='276.27' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='203.08' x2='51.84' y2='203.08' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='129.89' x2='51.84' y2='129.89' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,422.66) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,349.46) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,276.27) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,203.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,129.89) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<text x='157.37' y='267.36' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='62.69px' lengthAdjust='spacingAndGlyphs'>Mazda RX4</text>
+<text x='233.84' y='266.06' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='90.25px' lengthAdjust='spacingAndGlyphs'>Mazda RX4 Wag</text>
+<text x='153.63' y='239.42' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='61.36px' lengthAdjust='spacingAndGlyphs'>Datsun 710</text>
+<text x='271.87' y='258.87' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='77.36px' lengthAdjust='spacingAndGlyphs'>Hornet 4 Drive</text>
+<text x='263.60' y='297.54' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='98.03px' lengthAdjust='spacingAndGlyphs'>Hornet Sportabout</text>
+<text x='265.57' y='306.98' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='35.80px' lengthAdjust='spacingAndGlyphs'>Valiant</text>
+<text x='276.37' y='367.21' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.69px' lengthAdjust='spacingAndGlyphs'>Duster 360</text>
+<text x='239.06' y='216.00' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.69px' lengthAdjust='spacingAndGlyphs'>Merc 240D</text>
+<text x='235.13' y='239.42' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='50.02px' lengthAdjust='spacingAndGlyphs'>Merc 230</text>
+<text x='251.48' y='290.31' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='50.02px' lengthAdjust='spacingAndGlyphs'>Merc 280</text>
+<text x='263.60' y='315.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.69px' lengthAdjust='spacingAndGlyphs'>Merc 280C</text>
+<text x='325.46' y='333.10' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='66.02px' lengthAdjust='spacingAndGlyphs'>Merc 450SE</text>
+<text x='292.08' y='323.34' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='64.69px' lengthAdjust='spacingAndGlyphs'>Merc 450SL</text>
+<text x='332.81' y='353.46' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='73.36px' lengthAdjust='spacingAndGlyphs'>Merc 450SLC</text>
+<text x='441.32' y='425.22' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='101.39px' lengthAdjust='spacingAndGlyphs'>Cadillac Fleetwood</text>
+<text x='458.40' y='416.96' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='102.06px' lengthAdjust='spacingAndGlyphs'>Lincoln Continental</text>
+<text x='450.64' y='356.96' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='90.70px' lengthAdjust='spacingAndGlyphs'>Chrysler Imperial</text>
+<text x='141.85' y='99.05' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='43.34px' lengthAdjust='spacingAndGlyphs'>Fiat 128</text>
+<text x='84.41' y='132.45' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>Honda Civic</text>
+<text x='106.02' y='75.90' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='76.70px' lengthAdjust='spacingAndGlyphs'>Toyota Corolla</text>
+<text x='133.47' y='256.79' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='78.03px' lengthAdjust='spacingAndGlyphs'>Toyota Corona</text>
+<text x='271.46' y='341.41' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='96.73px' lengthAdjust='spacingAndGlyphs'>Dodge Challenger</text>
+<text x='244.87' y='350.86' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>AMC Javelin</text>
+<text x='302.88' y='378.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='66.69px' lengthAdjust='spacingAndGlyphs'>Camaro Z28</text>
+<text x='318.51' y='290.47' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='84.03px' lengthAdjust='spacingAndGlyphs'>Pontiac Firebird</text>
+<text x='115.83' y='173.70' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='48.67px' lengthAdjust='spacingAndGlyphs'>Fiat X1-9</text>
+<text x='135.96' y='192.73' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='78.03px' lengthAdjust='spacingAndGlyphs'>Porsche 914-2</text>
+<text x='74.40' y='122.79' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='71.36px' lengthAdjust='spacingAndGlyphs'>Lotus Europa</text>
+<text x='237.09' y='334.34' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='80.02px' lengthAdjust='spacingAndGlyphs'>Ford Pantera L</text>
+<text x='194.80' y='284.96' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='63.36px' lengthAdjust='spacingAndGlyphs'>Ferrari Dino</text>
+<text x='258.78' y='359.11' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='74.69px' lengthAdjust='spacingAndGlyphs'>Maserati Bora</text>
+<text x='202.84' y='258.99' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='60.70px' lengthAdjust='spacingAndGlyphs'>Volvo 142E</text>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-tinylabel.R
+++ b/inst/tinytest/test-tinylabel.R
@@ -48,3 +48,8 @@ expect_equal(
   tinylabel(c(-1000, 2000), "$"),
   c("-$1,000", "$2,000")
 )
+# Non-numeric input (e.g. categorical axis labels reaching a numeric labeller
+# via flip = TRUE) should be returned unchanged, without "NAs introduced by
+# coercion" warnings (#622).
+spp = c("Adelie", "Gentoo", "Chinstrap")
+expect_equal(tinylabel(spp, ","), spp)

--- a/inst/tinytest/test-type_text.R
+++ b/inst/tinytest/test-type_text.R
@@ -38,3 +38,12 @@ f = function() {
   tinyplot_add(type = type_text(labeller = "%", adj = c(0.5, -0.5)))
 }
 expect_snapshot_plot(f, label = "text_labeller_percent")
+
+
+# repel arg nudges overlapping labels apart (#318)
+f = function() {
+  tinyplot(mpg ~ wt, data = mtcars,
+    type = type_text(labels =  row.names(mtcars), repel = TRUE),
+    main = "repel = TRUE")
+}
+expect_snapshot_plot(f, label = "text_repel")

--- a/man/type_text.Rd
+++ b/man/type_text.Rd
@@ -15,6 +15,7 @@ type_text(
   vfont = NULL,
   xpd = NULL,
   srt = 0,
+  repel = FALSE,
   clim = c(0.5, 2.5)
 )
 }
@@ -65,6 +66,17 @@ regular, \code{2} = bold, \code{3} = italic, \code{4} = bold italic, and \code{5
 
 \item{srt}{Numeric giving the desired string rotation in degrees.}
 
+\item{repel}{Logical or numeric controlling automatic repulsion of
+overlapping text labels. The default \code{FALSE} draws the labels at their
+exact (\code{x},\code{y}) coordinates. \code{TRUE} nudges overlapping labels apart using a
+force-directed algorithm (labels are pushed off each other and then sprung
+back toward their original positions). A numeric value does the same but
+additionally enforces that much minimum padding (in user coordinates)
+between labels. Works best with the default centered text placement (i.e.
+without \code{pos}). \strong{Caveat:} The repulsion logic currently operates
+within each group rather than across groups. So the text of different
+groups may still overlap. See Examples.}
+
 \item{clim}{Numeric giving the lower and upper limits of the character
 expansion (\code{cex}) normalization for bubble charts.}
 }
@@ -79,9 +91,18 @@ tinyplot(1:12, type = "text")
 # pass explicit `labels` arg if you want specific text
 tinyplot(1:12, type = "text", labels = month.abb)
 
+# you can also use a labeller function (passed to `tinylabel`) to
+# customize
+tinyplot(1:12, type = "text", labels = month.abb, labeller = toupper)
+
 # for advanced customization, it's safer to pass args through `type_text()`
-tinyplot(1:12, type = type_text(
-  labels = month.abb, family = "HersheyScript", srt = -20))
+tinyplot(
+  1:12,
+  type = type_text(
+  labels = month.abb,
+  family = "HersheyScript",
+  srt = -20)
+)
 
 # same principles apply to grouped and/or facet data
 tinyplot(mpg ~ hp | factor(cyl),
@@ -106,9 +127,17 @@ tinyplot(mpg ~ hp | factor(cyl),
   )
 )
 
-# use `labeller` to format the labels, e.g. to match a formatted axis
-d = data.frame(x = c("A", "B"), y = c(0.5, 0.8))
-tinyplot(y ~ x, data = d, type = "bar", ylim = c(0, 1), yaxl = "\%")
-tinyplot_add(type = type_text(labeller = "\%", adj = c(0.5, -0.5)))
+# use `repel = TRUE` to automically nudge overlapping labels apart
+tinyplot(
+  mpg ~ wt, data = mtcars,
+  type = type_text(labels = row.names(mtcars), repel = TRUE)
+)
+
+# limitation: `repel` logic currently works per group, so grouped text data
+# may still overlap
+tinyplot(
+  mpg ~ wt | factor(cyl), data = mtcars,
+  type = type_text(labels = row.names(mtcars), repel = TRUE)
+)
 
 }


### PR DESCRIPTION
Partially closes #318. Builds on the same `repel.R` function that was introduced in the direct labels PR (#589)

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
tinyplot(mpg ~ wt, data = mtcars,
  type = type_text(labels = row.names(mtcars), xpd = NA))
```

![](https://i.imgur.com/FxUWOrf.png)<!-- -->

versus

``` r
tinyplot(mpg ~ wt, data = mtcars,
  type = type_text(labels = row.names(mtcars), xpd = NA, repel = TRUE))
```

![](https://i.imgur.com/uXQiLWg.png)<!-- -->


**Two limitations:**

1. We don't adjust the plot region and margins in response to the text width or height, so these can overflow the plot/device region (but that's a pre-existing issue).

2. The repulsion logic operates at the group level. So, while we can guarantee that text will be dodged within groups, there may still be overlaps across groups. (Fixing this requires a more heavy-handed change to the code and will likely necessitate a second pass through the main `tinyplot.R` code. So I'm not sure it's worth it.)

``` r
tinyplot(mpg ~ wt | factor(cyl), data = mtcars,
  type = type_text(labels = row.names(mtcars), xpd = NA, repel = TRUE, ))
```

![](https://i.imgur.com/dh2xgUg.png)<!-- -->

<sup>Created on 2026-06-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
 