### PR TITLE
tinylabel: Non-numeric gotcha

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -187,7 +187,7 @@ Theme fixes:
   `"$0.50"` rather than `"$0.5"`), while still keeping clean integers
   integer-valued (e.g. `"$1,000"`), and place the negative sign in front of the
   currency symbol (e.g. `"-$1.50"` rather than `"$-1.50"`).
-  (#618 @grantmcdermott)
+  (#618, #623 @grantmcdermott)
 
 ## v0.6.1
 

--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -195,5 +195,19 @@ labeller_fun = function(label = "percent") {
   )
 
   ## combine with absolute value if necessary
-  if (abs_) function(x) fun(abs(x)) else fun
+  numeric_fun = if (abs_) function(x) fun(abs(x)) else fun
+
+  # The built-in formatters coerce their input via as.numeric(). Guard against
+  # non-numeric input (e.g. categorical axis labels reaching a numeric labeller
+  # via flip = TRUE) by leaving such values unchanged, which avoids "NAs
+  # introduced by coercion" warnings (#622). The is.na(xn) & !is.na(x) test only
+  # flags values that became NA through coercion, so genuine NA input still
+  # reaches the formatter.
+  function(x) {
+    xn = suppressWarnings(as.numeric(x))
+    if (any(is.na(xn) & !is.na(x))) {
+      return(x)
+    }
+    numeric_fun(x)
+  }
 }

--- a/inst/tinytest/test-tinylabel.R
+++ b/inst/tinytest/test-tinylabel.R
@@ -48,3 +48,8 @@ expect_equal(
   tinylabel(c(-1000, 2000), "$"),
   c("-$1,000", "$2,000")
 )
+# Non-numeric input (e.g. categorical axis labels reaching a numeric labeller
+# via flip = TRUE) should be returned unchanged, without "NAs introduced by
+# coercion" warnings (#622).
+spp = c("Adelie", "Gentoo", "Chinstrap")
+expect_equal(tinylabel(spp, ","), spp)


### PR DESCRIPTION
Fixes #622

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
plt(
  body_mass ~ species | sex, data = penguins,
  type = type_boxplot(boxwex = 0.6, staplewex = 0, outline = FALSE),
  lty = 1,
  flip = TRUE, yaxl = ",",
  main = "Penguins in boxplot form",
  sub = "Also using a different theme",
  theme = "ipsum"
)
plt_add(type = 'jitter', alpha = 0.5)
```

![](https://i.imgur.com/txeMJCE.png)<!-- -->

<sup>Created on 2026-06-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>