### PR TITLE
ci: switch workflows to r-ci/r2u for fast binary installs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,6 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Workflow derived from https://eddelbuettel.github.io/r-ci/
+# Uses r-ci + r2u for fast (binary) package installation. R-devel coverage is
+# provided via the rocker/drd container (itself built FROM rocker/r2u).
 on:
   push:
     branches: [main, master]
@@ -9,41 +10,31 @@ on:
 name: ci
 
 jobs:
-  R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
+  ci:
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.name }}
 
     strategy:
       fail-fast: false
       matrix:
-        config:
-          # - {os: macos-latest,   r: 'release'}
-          # - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          # - {os: ubuntu-latest,   r: 'oldrel-1'}
+        include:
+          - { name: r-release, os: ubuntu-latest }
+          - { name: r-devel,   os: ubuntu-latest, container: rocker/drd }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+      - name: Dependencies
+        run: ./run.sh install_all
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
+      - name: Test
+        run: ./run.sh run_tests

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,7 +1,8 @@
 # Workflow derived from https://eddelbuettel.github.io/r-ci/
 # Uses r-ci + r2u for fast (binary) package installation. Both jobs run in
-# containers that already bundle r2u (rocker/r2u for release, rocker/drd for
-# devel, the latter built FROM rocker/r2u), so neither pays the bare-runner
+# containers that already bundle r2u (rocker/r2u4ci for release -- the
+# CI-flavoured image recommended by r-ci, with curl etc. preinstalled -- and
+# rocker/drd for devel, built FROM rocker/r2u), so neither pays the bare-runner
 # r2u mirror-setup cost (which can stall if the upstream r2u mirror is down).
 on:
   push:
@@ -22,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: r-release, os: ubuntu-latest, container: rocker/r2u }
+          - { name: r-release, os: ubuntu-latest, container: rocker/r2u4ci }
           - { name: r-devel,   os: ubuntu-latest, container: rocker/drd }
 
     env:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,8 @@
 # Workflow derived from https://eddelbuettel.github.io/r-ci/
-# Uses r-ci + r2u for fast (binary) package installation. R-devel coverage is
-# provided via the rocker/drd container (itself built FROM rocker/r2u).
+# Uses r-ci + r2u for fast (binary) package installation. Both jobs run in
+# containers that already bundle r2u (rocker/r2u for release, rocker/drd for
+# devel, the latter built FROM rocker/r2u), so neither pays the bare-runner
+# r2u mirror-setup cost (which can stall if the upstream r2u mirror is down).
 on:
   push:
     branches: [main, master]
@@ -20,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: r-release, os: ubuntu-latest }
+          - { name: r-release, os: ubuntu-latest, container: rocker/r2u }
           - { name: r-devel,   os: ubuntu-latest, container: rocker/drd }
 
     env:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: quarto-dev/quarto-actions/setup@v2
 

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -14,6 +14,9 @@ name: altdoc
 jobs:
   altdoc:
     runs-on: ubuntu-latest
+    # Fail fast (and retryably) if the bare-runner r2u bootstrap stalls on a
+    # flaky upstream mirror, rather than burning a full-length run.
+    timeout-minutes: 20
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: altdoc-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -23,7 +23,7 @@ jobs:
           curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: set-matrix
         run: |
@@ -71,7 +71,7 @@ jobs:
           curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # r2u: installs CRAN packages as apt binaries and auto-resolves their
       # system (OS) dependencies, so no manual system_requirements() step is

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -8,13 +8,12 @@ name: revdep
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     name: Collect revdeps
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
@@ -24,7 +23,7 @@ jobs:
           curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
         shell: bash
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: set-matrix
         run: |
@@ -40,7 +39,7 @@ jobs:
         shell: Rscript {0}
 
   check-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: matrix
     steps:
       - name: Install json2yaml
@@ -56,14 +55,13 @@ jobs:
 
   R-CMD-check:
     needs: matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.package }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
@@ -73,12 +71,12 @@ jobs:
           curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
         shell: bash
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use RSPM
-        run: |
-          mkdir -p /home/runner/work/_temp/Library
-          echo 'local({release <- system2("lsb_release", "-sc", stdout = TRUE); options(repos=c(CRAN = paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest")), HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))}); .libPaths("/home/runner/work/_temp/Library")' | sudo tee /etc/R/Rprofile.site
+      # r2u: installs CRAN packages as apt binaries and auto-resolves their
+      # system (OS) dependencies, so no manual system_requirements() step is
+      # needed. Replaces the old hand-written /etc/R/Rprofile.site mirror hack.
+      - uses: eddelbuettel/github-actions/r2u-setup@master
 
       - name: Install remotes
         run: |
@@ -87,14 +85,6 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/setup-pandoc@v2
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "22.04")); package <- "${{ matrix.package }}"; deps <- tools::package_dependencies(package, which = "Suggests")[[1]]; lapply(c(package, deps), function(x) { writeLines(remotes::system_requirements("ubuntu", "22.04", package = x)) })' | sort | uniq > .github/deps.sh
-          cat .github/deps.sh
-          sudo sh < .github/deps.sh
 
       - name: Install package
         run: |
@@ -173,7 +163,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}-results
           path: revdep/${{ matrix.package }}


### PR DESCRIPTION
## Why

A recent `revdep` run stalled for ~68 min, and a later `altdoc` run took ~41 min — but on investigation these were almost certainly a **temporary upstream blip** (a flaky package mirror / GitHub runner network), not a structural problem with our config. Both the GitHub Actions status and the r2u mirror were healthy again shortly after.

Rather than just wait it out, we took it as an **opportune moment to modernize and standardize** the CI components that had drifted: dated action versions, a hardcoded/legacy package-mirror endpoint, and three workflows each setting up R a different way. The result is faster, more consistent, and less exposed to this class of hiccup going forward.

Headline result: the `ci` jobs now complete in **~1–1.5 min** each.

## Changes

- **R-CMD-check.yaml**: replace `r-lib/actions/*` with `eddelbuettel/github-actions/r-ci`, running both jobs in r2u-bundled containers (apt-binary installs; no bare-runner mirror-setup cost):
  - `r-release` → `container: rocker/r2u4ci` (CI-flavoured r2u image; bundles curl/sudo/etc. the r-ci action needs).
  - `r-devel` → `container: rocker/drd` (built `FROM rocker/r2u`, so devel installs are binaries too). R-devel coverage retained. tinyplot is zero-dependency pure base R, so the r2u-built-for-release / devel ABI caveat doesn't apply to its own check.
- **revdep.yaml**: *surgical* toolchain swap only. Add `eddelbuettel/github-actions/r2u-setup`; drop the vestigial `RSPM` env vars, the hand-written `/etc/R/Rprofile.site` mirror hack (legacy `packagemanager.rstudio.com` host), and the manual `system_requirements` step (r2u auto-resolves OS deps via apt). **Old-vs-new compare logic unchanged.**
- **altdoc.yaml**: add `timeout-minutes: 20`. Left on the bare runner deliberately — its slow run traced to the same transient mirror blip, not a structural issue. The timeout makes any future stall fail fast and retryable instead of burning a full-length run.
- Housekeeping / standardization: `actions/checkout@v6` (clears the Node 20 deprecation warning; matches the deploy action's README), `actions/upload-artifact@v4` (was a floating `@main`), `ubuntu-24.04`.

## Testing

- `ci` (R-CMD-check): **both `r-release` (~1m10s) and `r-devel` (~1m32s) pass**, installing via r2u in-container.
- `altdoc`: passes (deploy step correctly skipped on PR events).
- `revdep` only triggers on `revdep*` branches, so it is **not exercised by this PR** — to be validated separately via a throwaway `revdep-citest` branch (matrix collects revdeps; r2u installs them as binaries; old-vs-new compare runs).

## Notes / follow-ups

- **revdep** still uses a bare-runner `r2u-setup`, so it retains some exposure to upstream r2u-mirror flakiness; containerize later if it proves recurrent.
- **altdoc** likewise remains bare-runner by choice (see above); revisit `container: rocker/r2u4ci` only if stalls recur on separate days (would also need `git` + `rsync` installed for the gh-pages deploy, which a PR can't validate).