### PR TITLE
Fix no annotation issue 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -240,6 +240,9 @@ Theme fixes:
   arguments that rely on non-standard evaluation against `data` (e.g.,
   `plt_add(..., subset = <>)`) resolve correctly instead of erroring with 
   "object not found". (#638 @grantmcdermott)
+- `plt(..., ann = FALSE)` correctly turns off title annotations now, fixing a
+  regression that we missed from at least v0.6.0. Thanks to @bastistician for
+  the report. (#641 @zeileis)
 
 ## v0.6.1
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1244,7 +1244,8 @@ tinyplot.default = function(
       }
     }
 
-    draw_title(main, sub, cap, xlab, ylab, legend, legend_args, opar,
+    ann = as.logical(ann)
+    draw_title(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann,
                xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_x_raw else 0,
                ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_y_raw - max(0, .ymgp_shift) - .ylab_cex_shift else 0)
   }

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1245,9 +1245,9 @@ tinyplot.default = function(
     }
 
     ann = as.logical(ann)
-    draw_title(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann,
-               xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_x_raw else 0,
-               ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_y_raw - max(0, .ymgp_shift) - .ylab_cex_shift else 0)
+    if (ann) draw_title(main, sub, cap, xlab, ylab, legend, legend_args, opar,
+                        xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_x_raw else 0,
+                        ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_y_raw - max(0, .ymgp_shift) - .ylab_cex_shift else 0)
   }
 
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1245,9 +1245,11 @@ tinyplot.default = function(
     }
 
     ann = as.logical(ann)
-    if (ann) draw_title(main, sub, cap, xlab, ylab, legend, legend_args, opar,
-                        xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_x_raw else 0,
-                        ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_y_raw - max(0, .ymgp_shift) - .ylab_cex_shift else 0)
+    if (ann) draw_title(
+      main, sub, cap, xlab, ylab, legend, legend_args, opar,
+      xlab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_x_raw else 0,
+      ylab_line_offset = if (!is.null(dynmar_computed)) .whtsbp_y_raw - max(0, .ymgp_shift) - .ylab_cex_shift else 0
+    )
   }
 
 

--- a/R/title.R
+++ b/R/title.R
@@ -68,7 +68,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
       las = 1
     )
     args = Filter(function(x) !is.null(x), args)
-    do.call(mtext, args)
+    if (ann) do.call(mtext, args)
   }
 
   if (!is.null(main)) {

--- a/R/title.R
+++ b/R/title.R
@@ -1,4 +1,4 @@
-draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
+draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann,
                       xlab_line_offset = 0,
                       ylab_line_offset = 0) {
   # main title
@@ -88,7 +88,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
       font.main = get_tpar("font.main", 2),
       adj = get_tpar(c("adj.main", "adj"), 3))
     args = Filter(function(x) !is.null(x), args)
-    do.call(title, args)
+    if (ann) do.call(title, args)
     par(xpd = .oxpd)
   }
 
@@ -111,7 +111,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
       las = 1
     )
     args = Filter(function(x) !is.null(x), args)
-    do.call(mtext, args)
+    if (ann) do.call(mtext, args)
   }
 
   # Axis titles. For multi-line labels, base R places line 1 at
@@ -138,7 +138,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
   }
   args[["adj"]] = get_tpar(c("adj.xlab", "adj"))
   args[["cex.lab"]] = cex_xlab
-  do.call(title, args)
+  if (ann) do.call(title, args)
 
   # ylab: base R already places multi-line text correctly (outermost line at
   # mgp[1], subsequent lines closer to the plot), so no line shift needed.
@@ -149,5 +149,5 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
   }
   args[["adj"]] = get_tpar(c("adj.ylab", "adj"))
   args[["cex.lab"]] = cex_ylab
-  do.call(title, args)
+  if (ann) do.call(title, args)
 }

--- a/R/title.R
+++ b/R/title.R
@@ -1,4 +1,4 @@
-draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann,
+draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
                       xlab_line_offset = 0,
                       ylab_line_offset = 0) {
   # main title
@@ -68,7 +68,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
       las = 1
     )
     args = Filter(function(x) !is.null(x), args)
-    if (ann) do.call(mtext, args)
+    do.call(mtext, args)
   }
 
   if (!is.null(main)) {
@@ -88,7 +88,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
       font.main = get_tpar("font.main", 2),
       adj = get_tpar(c("adj.main", "adj"), 3))
     args = Filter(function(x) !is.null(x), args)
-    if (ann) do.call(title, args)
+    do.call(title, args)
     par(xpd = .oxpd)
   }
 
@@ -111,7 +111,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
       las = 1
     )
     args = Filter(function(x) !is.null(x), args)
-    if (ann) do.call(mtext, args)
+    do.call(mtext, args)
   }
 
   # Axis titles. For multi-line labels, base R places line 1 at
@@ -138,7 +138,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
   }
   args[["adj"]] = get_tpar(c("adj.xlab", "adj"))
   args[["cex.lab"]] = cex_xlab
-  if (ann) do.call(title, args)
+  do.call(title, args)
 
   # ylab: base R already places multi-line text correctly (outermost line at
   # mgp[1], subsequent lines closer to the plot), so no line shift needed.
@@ -149,5 +149,5 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar, ann
   }
   args[["adj"]] = get_tpar(c("adj.ylab", "adj"))
   args[["cex.lab"]] = cex_ylab
-  if (ann) do.call(title, args)
+  do.call(title, args)
 }

--- a/inst/tinytest/_tinysnapshot/ann_FALSE.svg
+++ b/inst/tinytest/_tinysnapshot/ann_FALSE.svg
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='74.40' y1='430.56' x2='458.40' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='74.40' y1='430.56' x2='74.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='170.40' y1='430.56' x2='170.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='266.40' y1='430.56' x2='266.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='362.40' y1='430.56' x2='362.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='430.56' x2='458.40' y2='437.76' style='stroke-width: 0.75;' />
+<text x='74.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='170.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='266.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='362.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='458.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='59.04' y1='416.80' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='416.80' x2='51.84' y2='416.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='330.80' x2='51.84' y2='330.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='244.80' x2='51.84' y2='244.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.80' x2='51.84' y2='158.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,416.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text transform='translate(41.76,330.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.67px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text transform='translate(41.76,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(41.76,158.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='266.40' cy='244.80' r='2.70' style='stroke-width: 0.75;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-misc.R
+++ b/inst/tinytest/test-misc.R
@@ -148,3 +148,9 @@ f = function() {
   tinyplot(Sepal.Length ~ 1, data = iris, xlab = "My X", ylab = "My Y")
 }
 expect_snapshot_plot(f, label = "formula_y1_cust_lab")
+
+# ann = FALSE turns off titles (#626)
+f = function() {
+  plt(0, 0, ann = FALSE)
+}
+expect_snapshot_plot(f, label = "ann=FALSE")


### PR DESCRIPTION
Fixes #626 

For compatibility with base R `tinyplot(..., ann = FALSE)` should suppress title and axis notation.

This is implemented now by passing the `ann` argument to `draw_title()` and only drawing `title()` and `mtext()` elements if `ann = TRUE`.