### PR TITLE
Fix CI snapshot testing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      NOT_CRAN: true
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Follow up to #633

It turns out that the CI wasn't actually running the `tinytest` suite b/c the `NOT_CRAN` envvar wasn't set correctly 😬