### PR TITLE
Smart `x/ylim` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -236,7 +236,7 @@ Theme fixes:
     column arrangements. (#562 @zeileis)
     - `plt(..., facet = z ~ 1)` <-> `plt(..., facet = ~z, facet.args = list(ncol = 1))`
     - `plt(..., facet = 1 ~ z)` <-> `plt(..., facet = ~z, facet.args = list(nrow = 1))`.
-  - `x/ylim` gain several "smart" override forms. (#616 @grantmcdermott)
+  - `x/ylim` gain several "smart" override forms. (#644 @grantmcdermott)
     - A single scalar (e.g. `ylim = 0`) ensures that value is covered by the
       axis range, e.g. for forcing zero onto a coefficient plot.
     - A length-2 vector with one `NA` (e.g. `ylim = c(0, NA)`) pins the non-`NA`

--- a/NEWS.md
+++ b/NEWS.md
@@ -236,6 +236,13 @@ Theme fixes:
     column arrangements. (#562 @zeileis)
     - `plt(..., facet = z ~ 1)` <-> `plt(..., facet = ~z, facet.args = list(ncol = 1))`
     - `plt(..., facet = 1 ~ z)` <-> `plt(..., facet = ~z, facet.args = list(nrow = 1))`.
+  - `x/ylim` gain several "smart" override forms. (#616 @grantmcdermott)
+    - A single scalar (e.g. `ylim = 0`) ensures that value is covered by the
+      axis range, e.g. for forcing zero onto a coefficient plot.
+    - A length-2 vector with one `NA` (e.g. `ylim = c(0, NA)`) pins the non-`NA`
+      limit and lets the data determine the other.
+    - The string `"rev` (or `"reverse"`) reverses the auto-computed axis range,
+      without needing to know the data extent in advance.
 - Type-specific updates:
   - `type_barplot()` gains an `offset` argument for shifting bar baselines away
     from zero. (#611, #615 @grantmcdermott @zeileis)

--- a/NEWS.md
+++ b/NEWS.md
@@ -241,7 +241,7 @@ Theme fixes:
       axis range, e.g. for forcing zero onto a coefficient plot.
     - A length-2 vector with one `NA` (e.g. `ylim = c(0, NA)`) pins the non-`NA`
       limit and lets the data determine the other.
-    - The string `"rev` (or `"reverse"`) reverses the auto-computed axis range,
+    - The string `"rev"` (or `"reverse"`) reverses the auto-computed axis range,
       without needing to know the data extent in advance.
 - Type-specific updates:
   - `type_barplot()` gains an `offset` argument for shifting bar baselines away

--- a/R/facet.R
+++ b/R/facet.R
@@ -25,6 +25,7 @@ draw_facet_window = function(
     axes, flip, frame.plot, oxaxis, oyaxis,
     xlabs, xlim, null_xlim, xaxt, xaxs, xaxb, xaxl,
     ylabs, ylim, null_ylim, yaxt, yaxs, yaxb, yaxl,
+    rev_x = FALSE, rev_y = FALSE,
     asp, log,
     # other args (in approx. alphabetical + group ordering)
     dots,
@@ -355,8 +356,11 @@ draw_facet_window = function(
         yfree = if (!is.null(facet)) split(c(y, ymin, ymax), facet)[[ii]] else c(y, ymin, ymax)
         if (null_xlim) xlim = range(xfree, na.rm = TRUE)
         if (null_ylim) ylim = range(yfree, na.rm = TRUE)
+        # extendrange() returns an ascending pair, so reverse afterwards
         xext = extendrange(xlim, f = 0.04)
         yext = extendrange(ylim, f = 0.04)
+        if (isTRUE(rev_x)) xext = rev(xext)
+        if (isTRUE(rev_y)) yext = rev(yext)
         # We'll save this in a special .fusr env var (list) that we'll re-use
         # when it comes to plotting the actual elements later
         if (ii == 1) {

--- a/R/facet.R
+++ b/R/facet.R
@@ -356,16 +356,23 @@ draw_facet_window = function(
         yfree = if (!is.null(facet)) split(c(y, ymin, ymax), facet)[[ii]] else c(y, ymin, ymax)
         if (null_xlim) xlim = range(xfree, na.rm = TRUE)
         if (null_ylim) ylim = range(yfree, na.rm = TRUE)
+        # An axis is reversed either via the `rev_x`/`rev_y` flag (e.g. the
+        # "reverse" keyword) or when the user supplies descending fixed limits
+        # (e.g. xlim = c(10, 0)). The latter must be detected before extendrange()
+        # below, which always returns an ascending pair and would otherwise drop
+        # the descending order. (#644)
+        rev_xext = isTRUE(rev_x) || (!null_xlim && length(xlim) == 2L && xlim[2L] < xlim[1L])
+        rev_yext = isTRUE(rev_y) || (!null_ylim && length(ylim) == 2L && ylim[2L] < ylim[1L])
         # extendrange() returns an ascending pair, so reverse afterwards
-        xext = extendrange(xlim, f = 0.04)
-        yext = extendrange(ylim, f = 0.04)
+        xext = extendrange(sort(xlim), f = 0.04)
+        yext = extendrange(sort(ylim), f = 0.04)
         # base axTicks() misbehaves on a reversed usr (it collapses to a single
         # tick), so precompute ticks from the ascending extent and pass them as
         # an explicit `at` below; placement against the reversed usr is fine.
-        xat = if (isTRUE(rev_x)) axisTicks(usr = xext, log = par("xlog")) else NULL
-        yat = if (isTRUE(rev_y)) axisTicks(usr = yext, log = par("ylog")) else NULL
-        if (isTRUE(rev_x)) xext = rev(xext)
-        if (isTRUE(rev_y)) yext = rev(yext)
+        xat = if (rev_xext) axisTicks(usr = xext, log = par("xlog")) else NULL
+        yat = if (rev_yext) axisTicks(usr = yext, log = par("ylog")) else NULL
+        if (rev_xext) xext = rev(xext)
+        if (rev_yext) yext = rev(yext)
         # We'll save this in a special .fusr env var (list) that we'll re-use
         # when it comes to plotting the actual elements later
         if (ii == 1) {

--- a/R/facet.R
+++ b/R/facet.R
@@ -359,6 +359,11 @@ draw_facet_window = function(
         # extendrange() returns an ascending pair, so reverse afterwards
         xext = extendrange(xlim, f = 0.04)
         yext = extendrange(ylim, f = 0.04)
+        # base axTicks() misbehaves on a reversed usr (it collapses to a single
+        # tick), so precompute ticks from the ascending extent and pass them as
+        # an explicit `at` below; placement against the reversed usr is fine.
+        xat = if (isTRUE(rev_x)) axisTicks(usr = xext, log = par("xlog")) else NULL
+        yat = if (isTRUE(rev_y)) axisTicks(usr = yext, log = par("ylog")) else NULL
         if (isTRUE(rev_x)) xext = rev(xext)
         if (isTRUE(rev_y)) yext = rev(yext)
         # We'll save this in a special .fusr env var (list) that we'll re-use
@@ -375,12 +380,16 @@ draw_facet_window = function(
         # if plot frame is true then print axes per normal...
         if (type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "p", "violin") && !is.null(xlabs)) {
           tinyAxis(xfree, side = xside, at = xlabs, labels = names(xlabs), type = xaxt, labeller = xaxl)
+        } else if (!is.null(xat)) {
+          tinyAxis(xfree, side = xside, at = xat, type = xaxt, labeller = xaxl)
         } else {
           tinyAxis(xfree, side = xside, type = xaxt, labeller = xaxl)
         }
         if (.ymgp_shift > 0) par(mgp = par("mgp") - c(0, .ymgp_shift, 0))
         if (isTRUE(flip) && type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "p", "violin") && !is.null(ylabs)) {
           tinyAxis(yfree, side = yside, at = ylabs, labels = names(ylabs), type = yaxt, labeller = yaxl)
+        } else if (!is.null(yat)) {
+          tinyAxis(yfree, side = yside, at = yat, type = yaxt, labeller = yaxl)
         } else {
           tinyAxis(yfree, side = yside, type = yaxt, labeller = yaxl)
         }

--- a/R/flip.R
+++ b/R/flip.R
@@ -30,6 +30,7 @@ flip_datapoints = function(settings) {
       swap_elements(settings, "xlab", "ylab")
       swap_elements(settings, "xlabs", "ylabs")
       swap_elements(settings, "xlim", "ylim")
+      swap_elements(settings, "rev_x", "rev_y")
       swap_elements(settings, "xmax", "ymax")
       swap_elements(settings, "xmin", "ymin")
 

--- a/R/lim.R
+++ b/R/lim.R
@@ -1,39 +1,12 @@
 # calculate limits of each plot
 
-# Resolve a user-supplied x/ylim that may be a scalar or contains a single NA.
-# `lim`  : raw user value (already known to be non-NULL)
-# `drng` : data range, 2-element numeric, i.e. range(..., finite = TRUE)
-# Returns a 2-element numeric vector (raw; window padding applied downstream).
-resolve_lim = function(lim, drng, arg = "xlim") {
-  if (!is.numeric(lim)) {
-    stop(sprintf("`%s` must be numeric (a scalar or length-2 vector).", arg), call. = FALSE)
-  }
-  n = length(lim)
-  if (n == 1L) {
-    if (is.na(lim)) stop(sprintf("`%s` cannot be a single `NA`.", arg), call. = FALSE)
-    # scalar: ensure the value is covered alongside the data
-    return(range(c(drng, lim)))
-  }
-  if (n == 2L) {
-    nas = is.na(lim)
-    if (all(nas)) {
-      stop(sprintf("`%s` cannot be `c(NA, NA)`; supply at least one finite limit.", arg), call. = FALSE)
-    }
-    if (!any(nas)) return(lim) # full override: unchanged (reversed axis OK)
-    # exactly one NA: fill that side from the data range, pin the other verbatim
-    if (nas[1L]) lim[1L] = drng[1L] else lim[2L] = drng[2L]
-    return(lim)
-  }
-  stop(sprintf("`%s` must be length 1 or 2, not length %d.", arg, n), call. = FALSE)
-}
-
 lim_args = function(settings) {
   env2env(
     settings,
     environment(),
     c(
-      "xaxb", "xlabs", "xlim", "null_xlim", 
-      "yaxb", "ylabs", "ylim", "null_ylim",
+      "xaxb", "xlabs", "xlim", "null_xlim", "rev_x",
+      "yaxb", "ylabs", "ylim", "null_ylim", "rev_y",
       "datapoints", "type"
     )
   )
@@ -77,10 +50,64 @@ lim_args = function(settings) {
   if (null_xlim && !is.null(xaxb) && type != "spineplot") xlim = range(c(xlim, xaxb))
   if (null_ylim && !is.null(yaxb) && type != "spineplot") ylim = range(c(ylim, yaxb))
 
+  # reverse axis direction last, once the range is otherwise finalized
+  if (isTRUE(rev_x)) xlim = rev(xlim)
+  if (isTRUE(rev_y)) ylim = rev(ylim)
+
   # update settings
   env2env(
     environment(),
     settings,
     c("xlim", "ylim", "xlabs", "ylabs", "xaxb", "yaxb")
   )
+}
+
+
+#
+# x/ylim helpers ----
+#
+
+# Resolve a user-supplied x/ylim that may be a scalar or contains a single NA.
+# `lim`  : raw user value (already known to be non-NULL)
+# `drng` : data range, 2-element numeric, i.e. range(..., finite = TRUE)
+# Returns a 2-element numeric vector (raw; window padding applied downstream).
+resolve_lim = function(lim, drng, arg = "xlim") {
+  if (!is.numeric(lim)) {
+    stop(sprintf("`%s` must be numeric (a scalar or length-2 vector).", arg), call. = FALSE)
+  }
+  n = length(lim)
+  if (n == 1L) {
+    if (is.na(lim)) stop(sprintf("`%s` cannot be a single `NA`.", arg), call. = FALSE)
+    # scalar: ensure the value is covered alongside the data
+    return(range(c(drng, lim)))
+  }
+  if (n == 2L) {
+    nas = is.na(lim)
+    if (all(nas)) {
+      stop(sprintf("`%s` cannot be `c(NA, NA)`; supply at least one finite limit.", arg), call. = FALSE)
+    }
+    if (!any(nas)) return(lim) # full override: unchanged (reversed axis OK)
+    # exactly one NA: fill that side from the data range, pin the other verbatim
+    if (nas[1L]) lim[1L] = drng[1L] else lim[2L] = drng[2L]
+    return(lim)
+  }
+  stop(sprintf("`%s` must be length 1 or 2, not length %d.", arg, n), call. = FALSE)
+}
+
+# Resolve an axis-reversal keyword passed to x/ylim, e.g. xlim = "reverse" (or
+# the "rev" abbreviation). Returns a list with the (possibly NULL-ified) limit
+# and a logical flag. When a keyword is detected we strip the limit back to NULL
+# so that all the usual auto-range machinery (data range, breaks, free facets,
+# type-specific limits) runs untouched; the flag is consumed later to rev() the
+# finalized range.
+sanitize_lim_rev = function(lim, arg = "xlim") {
+  if (is.character(lim)) {
+    rev_ok = length(lim) == 1L && !is.na(lim) &&
+      nchar(lim) >= 3L && pmatch(tolower(lim), "reverse", nomatch = 0L) == 1L
+    if (!rev_ok) {
+      stop(sprintf('If `%s` is a character string it must be "reverse" (or "rev").', arg), call. = FALSE)
+    }
+    return(list(lim = NULL, rev = TRUE))
+  }
+  list(lim = lim, rev = FALSE)
 }

--- a/R/lim.R
+++ b/R/lim.R
@@ -1,5 +1,32 @@
 # calculate limits of each plot
 
+# Resolve a user-supplied x/ylim that may be a scalar or contains a single NA.
+# `lim`  : raw user value (already known to be non-NULL)
+# `drng` : data range, 2-element numeric, i.e. range(..., finite = TRUE)
+# Returns a 2-element numeric vector (raw; window padding applied downstream).
+resolve_lim = function(lim, drng, arg = "xlim") {
+  if (!is.numeric(lim)) {
+    stop(sprintf("`%s` must be numeric (a scalar or length-2 vector).", arg), call. = FALSE)
+  }
+  n = length(lim)
+  if (n == 1L) {
+    if (is.na(lim)) stop(sprintf("`%s` cannot be a single `NA`.", arg), call. = FALSE)
+    # scalar: ensure the value is covered alongside the data
+    return(range(c(drng, lim)))
+  }
+  if (n == 2L) {
+    nas = is.na(lim)
+    if (all(nas)) {
+      stop(sprintf("`%s` cannot be `c(NA, NA)`; supply at least one finite limit.", arg), call. = FALSE)
+    }
+    if (!any(nas)) return(lim) # full override: unchanged (reversed axis OK)
+    # exactly one NA: fill that side from the data range, pin the other verbatim
+    if (nas[1L]) lim[1L] = drng[1L] else lim[2L] = drng[2L]
+    return(lim)
+  }
+  stop(sprintf("`%s` must be length 1 or 2, not length %d.", arg, n), call. = FALSE)
+}
+
 lim_args = function(settings) {
   env2env(
     settings,
@@ -26,11 +53,21 @@ lim_args = function(settings) {
     xlim = range(as.numeric(c(
       datapoints[["x"]], datapoints[["xmin"]],
       datapoints[["xmax"]])), finite = TRUE)
+  } else if (length(xlim) != 2L || anyNA(xlim)) {
+    xdrng = range(as.numeric(c(
+      datapoints[["x"]], datapoints[["xmin"]],
+      datapoints[["xmax"]])), finite = TRUE)
+    xlim = resolve_lim(xlim, xdrng, "xlim")
   }
   if (is.null(ylim)) {
     ylim = range(as.numeric(c(
       datapoints[["y"]], datapoints[["ymin"]],
       datapoints[["ymax"]])), finite = TRUE)
+  } else if (length(ylim) != 2L || anyNA(ylim)) {
+    ydrng = range(as.numeric(c(
+      datapoints[["y"]], datapoints[["ymin"]],
+      datapoints[["ymax"]])), finite = TRUE)
+    ylim = resolve_lim(ylim, ydrng, "ylim")
   }
 
   if (identical(type, "boxplot")) {

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -180,15 +180,19 @@
 #' @param ann a logical value indicating whether the default annotation (title
 #'   and x and y axis labels) should appear on the plot.
 #' @param xlim the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
-#'   and leads to a ‘reversed axis’. The default value, NULL, indicates that
-#'   the range of the `finite` values to be plotted should be used. Alongside
-#'   the standard length-2 vector (e.g., `xlim = c(0, 1)`, `tinyplot` supports
-#'   two further convenience forms. First, passing a single scalar (e.g.
-#'   `xlim = 0`) ensures that the provided value is covered by the axis range,
-#'   irespective of the data extent. Second, a length-2 vector with one `NA`
-#'   (e.g. `xlim = c(0, NA)`) pins the non-`NA` limit and lets the data
-#'   determine the other limit.
-#' @param ylim the y limits of the plot. Accepts input forms as `xlim`.
+#'   and leads to a reversed axis (although see the `"rev(erse)"` keyword option
+#'   below). The default value, `NULL`, indicates that the range of the `finite`
+#'   values to be plotted should be used. Alongside the standard length-2 vector
+#'   (e.g., `xlim = c(0, 1)`), `tinyplot` supports three further convenience
+#'   forms:
+#'   - a single scalar (e.g. `xlim = 0`) ensures that the provided value is
+#'     covered by the axis range, irrespective of the data extent.
+#'   - a length-2 vector with one `NA` (e.g. `xlim = c(0, NA)`) pins the
+#'     non-`NA` limit and lets the data determine the other limit.
+#'   - the convenience string `"rev"` (or the longer `"reverse"`) reverses the
+#'     automatically-computed axis range. This is equivalent to passing a
+#'     descending vector, but without having to know the data extent in advance.
+#' @param ylim the y limits of the plot. Accepts the same input forms as `xlim`.
 #' @param axes logical or character. Should axes be drawn (`TRUE` or `FALSE`)?
 #'   Or alternatively what type of axes should be drawn: `"standard"` (with
 #'   axis, ticks, and labels; equivalent to `TRUE`), `"none"` (no axes;
@@ -794,6 +798,13 @@ tinyplot.default = function(
 
   dots = list(...)
 
+  # resolve any axis-reversal keyword (e.g. xlim = "reverse") into a flag, and
+  # reset the limit to NULL so the normal auto-range path runs (see lim.R)
+  .revx = sanitize_lim_rev(xlim, "xlim")
+  xlim = .revx[["lim"]]; rev_x = .revx[["rev"]]
+  .revy = sanitize_lim_rev(ylim, "ylim")
+  ylim = .revy[["lim"]]; rev_y = .revy[["rev"]]
+
   settings_list = list(
     # save call to check user input later
     call          = match.call(),
@@ -855,6 +866,8 @@ tinyplot.default = function(
     frame.plot    = frame.plot,
     xlim          = xlim,
     ylim          = ylim,
+    rev_x         = rev_x,
+    rev_y         = rev_y,
 
     # flags to check user input (useful later on)
     null_by       = is.null(by),
@@ -1363,6 +1376,7 @@ tinyplot.default = function(
       oxaxis = oxaxis, oyaxis = oyaxis,
       xlabs = xlabs, xlim = xlim, null_xlim = null_xlim, xaxt = xaxt, xaxs = xaxs, xaxb = xaxb, xaxl = xaxl,
       ylabs = ylabs, ylim = ylim, null_ylim = null_ylim, yaxt = yaxt, yaxs = yaxs, yaxb = yaxb, yaxl = yaxl,
+      rev_x = rev_x, rev_y = rev_y,
       asp = asp, log = log,
       # other args (in approx. alphabetical + group ordering)
       dots = dots,
@@ -1395,6 +1409,7 @@ tinyplot.default = function(
       oxaxis = oxaxis, oyaxis = oyaxis,
       xlabs = xlabs, xlim = xlim, null_xlim = null_xlim, xaxt = xaxt, xaxs = xaxs, xaxb = xaxb, xaxl = xaxl,
       ylabs = ylabs, ylim = ylim, null_ylim = null_ylim, yaxt = yaxt, yaxs = yaxs, yaxb = yaxb, yaxl = yaxl,
+      rev_x = rev_x, rev_y = rev_y,
       asp = asp, log = log,
       dots = dots,
       draw = draw,

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -181,8 +181,14 @@
 #'   and x and y axis labels) should appear on the plot.
 #' @param xlim the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
 #'   and leads to a ‘reversed axis’. The default value, NULL, indicates that
-#'   the range of the `finite` values to be plotted should be used.
-#' @param ylim the y limits of the plot.
+#'   the range of the `finite` values to be plotted should be used. Alongside
+#'   the standard length-2 vector (e.g., `xlim = c(0, 1)`, `tinyplot` supports
+#'   two further convenience forms. First, passing a single scalar (e.g.
+#'   `xlim = 0`) ensures that the provided value is covered by the axis range,
+#'   irespective of the data extent. Second, a length-2 vector with one `NA`
+#'   (e.g. `xlim = c(0, NA)`) pins the non-`NA` limit and lets the data
+#'   determine the other limit.
+#' @param ylim the y limits of the plot. Accepts input forms as `xlim`.
 #' @param axes logical or character. Should axes be drawn (`TRUE` or `FALSE`)?
 #'   Or alternatively what type of axes should be drawn: `"standard"` (with
 #'   axis, ticks, and labels; equivalent to `TRUE`), `"none"` (no axes;

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,6 +75,8 @@
     "oxaxis",
     "oyaxis",
     "pch",
+    "rev_x",
+    "rev_y",
     "ribbon.alpha",
     "split_data",
     "tpars",

--- a/inst/tinytest/_tinysnapshot/lim_partial_na.svg
+++ b/inst/tinytest/_tinysnapshot/lim_partial_na.svg
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>speed</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='18.67px' lengthAdjust='spacingAndGlyphs'>dist</text>
+<line x1='92.69' y1='430.56' x2='458.40' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='92.69' y1='430.56' x2='92.69' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='184.11' y1='430.56' x2='184.11' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='275.54' y1='430.56' x2='275.54' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='366.97' y1='430.56' x2='366.97' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='430.56' x2='458.40' y2='437.76' style='stroke-width: 0.75;' />
+<text x='92.69' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='184.11' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='275.54' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='366.97' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='458.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>25</text>
+<line x1='59.04' y1='416.80' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='416.80' x2='51.84' y2='416.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='359.47' x2='51.84' y2='359.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='244.80' x2='51.84' y2='244.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='187.47' x2='51.84' y2='187.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='130.13' x2='51.84' y2='130.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,416.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,359.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,187.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,130.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='74.40' cy='411.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='388.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='129.26' cy='405.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='129.26' cy='353.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='147.54' cy='370.93' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='388.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='365.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='342.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='319.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='368.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='336.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='376.67' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='359.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='348.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='336.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='342.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='319.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='319.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='284.93' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='342.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='313.60' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='244.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='187.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='359.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='342.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='262.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='325.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='302.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='325.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='302.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='273.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='296.40' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='256.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='198.93' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='176.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='313.60' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='284.93' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='221.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='325.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='279.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='267.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='256.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='233.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='403.54' cy='227.60' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='421.83' cy='262.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='440.11' cy='216.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='440.11' cy='153.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='440.11' cy='150.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='440.11' cy='72.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='173.13' r='2.70' style='stroke-width: 0.75;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/lim_reverse.svg
+++ b/inst/tinytest/_tinysnapshot/lim_reverse.svg
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>speed</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='18.67px' lengthAdjust='spacingAndGlyphs'>dist</text>
+<line x1='440.11' y1='430.56' x2='74.40' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='440.11' y1='430.56' x2='440.11' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='348.69' y1='430.56' x2='348.69' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='257.26' y1='430.56' x2='257.26' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='165.83' y1='430.56' x2='165.83' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='74.40' y1='430.56' x2='74.40' y2='437.76' style='stroke-width: 0.75;' />
+<text x='74.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='165.83' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='257.26' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='348.69' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='440.11' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='422.63' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='422.63' x2='51.84' y2='422.63' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='364.33' x2='51.84' y2='364.33' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='306.02' x2='51.84' y2='306.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='247.72' x2='51.84' y2='247.72' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='189.41' x2='51.84' y2='189.41' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='131.11' x2='51.84' y2='131.11' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,422.63) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,364.33) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,306.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,247.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,189.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,131.11) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='458.40' cy='416.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='393.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='403.54' cy='410.97' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='403.54' cy='358.49' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='385.26' cy='375.99' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.97' cy='393.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='370.16' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='348.69' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='373.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='341.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='381.82' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='364.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='352.66' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='312.11' cy='341.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='293.83' cy='288.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='317.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='247.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='275.54' cy='189.41' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='364.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.26' cy='265.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='238.97' cy='306.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='306.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='220.69' cy='276.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='300.19' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='259.38' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='201.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='177.75' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='317.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='288.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='184.11' cy='224.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='282.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='271.04' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='259.38' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='165.83' cy='236.05' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='129.26' cy='230.22' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='110.97' cy='265.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='92.69' cy='218.56' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='92.69' cy='154.43' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='92.69' cy='151.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='92.69' cy='72.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='174.83' r='2.70' style='stroke-width: 0.75;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/lim_reverse_free_facet.svg
+++ b/inst/tinytest/_tinysnapshot/lim_reverse_free_facet.svg
@@ -1,0 +1,164 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>speed</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='18.67px' lengthAdjust='spacingAndGlyphs'>dist</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDIyMS43Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='162.72' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDIyMS43Ng==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='458.40' y1='221.76' x2='117.07' y2='221.76' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='221.76' x2='458.40' y2='228.96' style='stroke-width: 0.75;' />
+<line x1='373.07' y1='221.76' x2='373.07' y2='228.96' style='stroke-width: 0.75;' />
+<line x1='287.73' y1='221.76' x2='287.73' y2='228.96' style='stroke-width: 0.75;' />
+<line x1='202.40' y1='221.76' x2='202.40' y2='228.96' style='stroke-width: 0.75;' />
+<line x1='117.07' y1='221.76' x2='117.07' y2='228.96' style='stroke-width: 0.75;' />
+<text x='117.07' y='247.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>24</text>
+<text x='202.40' y='247.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>22</text>
+<text x='287.73' y='247.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='373.07' y='247.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>18</text>
+<text x='458.40' y='247.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>16</text>
+<line x1='59.04' y1='202.04' x2='59.04' y2='65.07' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='202.04' x2='51.84' y2='202.04' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='167.79' x2='51.84' y2='167.79' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='133.55' x2='51.84' y2='133.55' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='99.31' x2='51.84' y2='99.31' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='65.07' x2='51.84' y2='65.07' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,202.04) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,167.79) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,133.55) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,99.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(41.76,65.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<rect x='59.04' y='43.20' width='414.72' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='266.40' y='55.25' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='19.33px' lengthAdjust='spacingAndGlyphs'>fast</text>
+<polygon points='59.04,221.76 473.76,221.76 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDI2Ny44NHw0MzAuNTY='>
+    <rect x='59.04' y='267.84' width='414.72' height='162.72' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDI2Ny44NHw0MzAuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='458.40' y1='430.56' x2='109.31' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='430.56' x2='458.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='388.58' y1='430.56' x2='388.58' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='318.76' y1='430.56' x2='318.76' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='248.95' y1='430.56' x2='248.95' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='179.13' y1='430.56' x2='179.13' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='109.31' y1='430.56' x2='109.31' y2='437.76' style='stroke-width: 0.75;' />
+<text x='109.31' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>14</text>
+<text x='179.13' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>12</text>
+<text x='248.95' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='318.76' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='388.58' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='458.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<line x1='59.04' y1='428.40' x2='59.04' y2='273.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='428.40' x2='51.84' y2='428.40' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='389.76' x2='51.84' y2='389.76' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='351.13' x2='51.84' y2='351.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='312.50' x2='51.84' y2='312.50' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='273.87' x2='51.84' y2='273.87' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,428.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,389.76) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,351.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,312.50) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,273.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>80</text>
+<rect x='59.04' y='252.00' width='414.72' height='15.84' style='stroke-width: 0.75; stroke: none;' />
+<text x='266.40' y='264.05' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>slow</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,267.84 59.04,267.84 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDIyMS43Ng==)'>
+<circle cx='458.40' cy='215.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='202.04' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='415.73' cy='215.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='415.73' cy='202.04' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='415.73' cy='184.92' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='373.07' cy='198.61' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='373.07' cy='174.64' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='373.07' cy='140.40' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='373.07' cy='126.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='208.88' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='191.76' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.40' cy='154.10' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.73' cy='215.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.73' cy='188.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.73' cy='181.49' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.73' cy='174.64' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.73' cy='160.95' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.40' cy='157.52' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='159.73' cy='178.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='117.07' cy='150.67' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='117.07' cy='113.01' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='117.07' cy='111.29' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='117.07' cy='65.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='124.99' r='2.70' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDI2Ny44NHw0MzAuNTY=)'>
+<circle cx='458.40' cy='424.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='409.08' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='353.67' cy='420.67' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='353.67' cy='385.90' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='318.76' cy='397.49' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='283.85' cy='409.08' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='248.95' cy='393.63' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='248.95' cy='378.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='248.95' cy='362.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='214.04' cy='395.56' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='214.04' cy='374.31' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='179.13' cy='401.35' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='179.13' cy='389.76' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='179.13' cy='382.04' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='179.13' cy='374.31' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='144.22' cy='378.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='144.22' cy='362.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='144.22' cy='362.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='144.22' cy='339.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='109.31' cy='378.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='109.31' cy='358.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='109.31' cy='312.50' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='109.31' cy='273.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='389.76' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='378.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='324.09' r='2.70' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMTAyLjI0fDQ1OS4zNnw4Ny44NHwzNzIuOTY='>
+    <rect x='102.24' y='87.84' width='357.12' height='285.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTAyLjI0fDQ1OS4zNnw4Ny44NHwzNzIuOTY=)'>
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/lim_scalar_zero.svg
+++ b/inst/tinytest/_tinysnapshot/lim_scalar_zero.svg
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>speed</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='18.67px' lengthAdjust='spacingAndGlyphs'>dist</text>
+<line x1='74.40' y1='430.56' x2='458.40' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='74.40' y1='430.56' x2='74.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='151.20' y1='430.56' x2='151.20' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='228.00' y1='430.56' x2='228.00' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='304.80' y1='430.56' x2='304.80' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='381.60' y1='430.56' x2='381.60' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='458.40' y1='430.56' x2='458.40' y2='437.76' style='stroke-width: 0.75;' />
+<text x='74.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='151.20' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='228.00' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='304.80' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='381.60' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='458.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>25</text>
+<line x1='59.04' y1='422.63' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='422.63' x2='51.84' y2='422.63' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='364.33' x2='51.84' y2='364.33' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='306.02' x2='51.84' y2='306.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='247.72' x2='51.84' y2='247.72' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='189.41' x2='51.84' y2='189.41' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='131.11' x2='51.84' y2='131.11' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,422.63) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,364.33) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,306.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,247.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,189.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,131.11) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='135.84' cy='416.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='135.84' cy='393.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='181.92' cy='410.97' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='181.92' cy='358.49' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='197.28' cy='375.99' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='212.64' cy='393.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='370.16' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='228.00' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='243.36' cy='373.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='243.36' cy='341.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='258.72' cy='381.82' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='258.72' cy='364.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='258.72' cy='352.66' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='258.72' cy='341.00' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='274.08' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='274.08' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='274.08' cy='323.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='274.08' cy='288.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.44' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.44' cy='317.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.44' cy='247.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.44' cy='189.41' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='364.33' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='346.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='304.80' cy='265.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='320.16' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='320.16' cy='306.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='335.52' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='335.52' cy='306.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='335.52' cy='276.87' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='350.88' cy='300.19' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='350.88' cy='259.38' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='350.88' cy='201.07' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='350.88' cy='177.75' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.24' cy='317.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.24' cy='288.53' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='366.24' cy='224.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='329.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='282.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='271.04' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='259.38' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.60' cy='236.05' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='412.32' cy='230.22' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='427.68' cy='265.21' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='443.04' cy='218.56' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='443.04' cy='154.43' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='443.04' cy='151.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='443.04' cy='72.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='174.83' r='2.70' style='stroke-width: 0.75;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-lim.R
+++ b/inst/tinytest/test-lim.R
@@ -1,0 +1,26 @@
+source("helpers.R")
+using("tinysnapshot")
+
+# Smart x/ylim overrides (#616): scalar coverage, partial-NA limits, and the
+# axis-reversal keyword.
+
+# Partial NA: lower pinned at 0, upper driven by data.
+fun = function() tinyplot(dist ~ speed, data = cars, ylim = c(0, NA))
+expect_snapshot_plot(fun, label = "lim_partial_na")
+
+# Scalar coverage: ensure value is shown alongside the data (in this case will
+# be identical to previous plot since y value is not binding)
+fun = function() tinyplot(dist ~ speed, data = cars, xlim = 0, ylim = 100)
+expect_snapshot_plot(fun, label = "lim_scalar_zero")
+
+# Reversed x-axis via keyword.
+fun = function() tinyplot(dist ~ speed, data = cars, xlim = "reverse")
+expect_snapshot_plot(fun, label = "lim_reverse")
+
+# Reversed x-axis on free-scale facets (exercises the facet.R path).
+fun = function() {
+  fast = ifelse(cars$speed > 15, "fast", "slow")
+  tinyplot(dist ~ speed, facet = fast, data = cars,
+           facet.args = list(free = TRUE, ncol = 1), xlim = "reverse")
+}
+expect_snapshot_plot(fun, label = "lim_reverse_free_facet")

--- a/man/facet.Rd
+++ b/man/facet.Rd
@@ -41,6 +41,8 @@ draw_facet_window(
   yaxs,
   yaxb,
   yaxl,
+  rev_x = FALSE,
+  rev_y = FALSE,
   asp,
   log,
   dots,

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -332,10 +332,22 @@ can be customized via \code{\link[tinyplot]{tpar}} parameters \code{adj.cap},
 and x and y axis labels) should appear on the plot.}
 
 \item{xlim}{the x limits (x1, x2) of the plot. Note that x1 > x2 is allowed
-and leads to a ‘reversed axis’. The default value, NULL, indicates that
-the range of the \code{finite} values to be plotted should be used.}
+and leads to a reversed axis (although see the \code{"rev(erse)"} keyword option
+below). The default value, \code{NULL}, indicates that the range of the \code{finite}
+values to be plotted should be used. Alongside the standard length-2 vector
+(e.g., \code{xlim = c(0, 1)}), \code{tinyplot} supports three further convenience
+forms:
+\itemize{
+\item a single scalar (e.g. \code{xlim = 0}) ensures that the provided value is
+covered by the axis range, irrespective of the data extent.
+\item a length-2 vector with one \code{NA} (e.g. \code{xlim = c(0, NA)}) pins the
+non-\code{NA} limit and lets the data determine the other limit.
+\item the convenience string \code{"rev"} (or the longer \code{"reverse"}) reverses the
+automatically-computed axis range. This is equivalent to passing a
+descending vector, but without having to know the data extent in advance.
+}}
 
-\item{ylim}{the y limits of the plot.}
+\item{ylim}{the y limits of the plot. Accepts the same input forms as \code{xlim}.}
 
 \item{axes}{logical or character. Should axes be drawn (\code{TRUE} or \code{FALSE})?
 Or alternatively what type of axes should be drawn: \code{"standard"} (with


### PR DESCRIPTION
Fixes #616

## MWE

Reference plot for comparison.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
plt(dist ~ speed, data = cars)
```

![](https://i.imgur.com/2I7bmr3.png)<!-- -->

1. Scalar input ensures value coverage (here: x value is binding, but the y value isn't).
``` r
plt(dist ~ speed, data = cars, xlim = 0, ylim = 100)
```

![](https://i.imgur.com/zzVc9xs.png)<!-- -->

2. Partial NA pins one limit, let data set the other.
``` r
plt(dist ~ speed, data = cars, xlim = c(0, NA))
```

![](https://i.imgur.com/OEOn2sP.png)<!-- -->

3. "rev(erse)" keyword 
``` r
plt(dist ~ speed, data = cars, xlim = "reverse")
```

![](https://i.imgur.com/Si0lKsw.png)<!-- -->

<sup>Created on 2026-06-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
