### PR TITLE
Legend: support `title = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -265,6 +265,8 @@ Theme fixes:
   - Model-fit and various distribution types gain a `weights` argument; although
     this is best provided from the top-level `tinyplot()`/`plt()` call. See
     above.
+- `legend = list(title = FALSE)` now suppresses the legend title, matching the
+  existing `title = NULL` behaviour. (#653 @grantmcdermott)
 
 ### Bug fixes
 

--- a/R/legend.R
+++ b/R/legend.R
@@ -574,6 +574,8 @@ build_legend_args = function(
 
   # Set defaults
   if (!exists("title", where = legend_args)) legend_args[["title"]] = by_dep
+  # Treat title = FALSE the same as NULL, i.e. suppress the title (#652).
+  if (isFALSE(legend_args[["title"]])) legend_args[["title"]] = NULL
   legend_args[["pch"]] = legend_args[["pch"]] %||% pch
   legend_args[["lty"]] = legend_args[["lty"]] %||% lty
   legend_args[["col"]] = legend_args[["col"]] %||% col

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -166,7 +166,9 @@
 #'    effect as specifying NULL) and FALSE turns the legend off (same effect as
 #'    specifying "none").
 #'    - A list or, equivalently, a dedicated `legend()` function with supported
-#'    legend arguments, e.g. "bty", "horiz", and so forth.
+#'    legend arguments, e.g. "bty", "horiz", and so forth. To suppress the
+#'    legend title, set `title = NULL` or `title = FALSE`, e.g.
+#'    `legend = list(title = FALSE)`.
 #' @param main a main title for the plot, see also `title`.
 #' @param sub a subtitle for the plot.
 #' @param cap a caption for the plot, drawn at the bottom. Useful for

--- a/inst/tinytest/test-legend.R
+++ b/inst/tinytest/test-legend.R
@@ -124,6 +124,13 @@ f = function() tinyplot(
 )
 expect_snapshot_plot(f, label = "legend_title_null")
 
+# title = FALSE should suppress the title, just like title = NULL (#652)
+f = function() tinyplot(
+  Temp ~ Day | Month, data = aq,
+  legend = list(title = FALSE)
+)
+expect_snapshot_plot(f, label = "legend_title_null")
+
 f = function() tinyplot(
   Temp ~ Day | Month, data = aq,
   legend = legend(legend = month.abb[5:9])

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -310,7 +310,9 @@ labels in data units.
 effect as specifying NULL) and FALSE turns the legend off (same effect as
 specifying "none").
 \item A list or, equivalently, a dedicated \code{legend()} function with supported
-legend arguments, e.g. "bty", "horiz", and so forth.
+legend arguments, e.g. "bty", "horiz", and so forth. To suppress the
+legend title, set \code{title = NULL} or \code{title = FALSE}, e.g.
+\code{legend = list(title = FALSE)}.
 }}
 
 \item{main}{a main title for the plot, see also \code{title}.}

--- a/vignettes/gallery_figs/ellipse-penguins.R
+++ b/vignettes/gallery_figs/ellipse-penguins.R
@@ -6,7 +6,7 @@ plt(
   main = 'A waddle of penguins',
   sub = 'Species stick together',
   theme = 'web',
-  legend = list('top!', title = NULL)
+  legend = list('top!', title = FALSE)
 )
 plt_add(type = 'ellipse', fill = 0.1)
 # plt_add(type = 'chull', fill = 0.1, col = NA) ## another option

--- a/vignettes/gallery_figs/likert.R
+++ b/vignettes/gallery_figs/likert.R
@@ -21,7 +21,7 @@ plt(
   share ~ question | response, data = lik,
   type = "barplot", center = TRUE, offset = "Unsure",
   flip = TRUE, xlab = NA, ylab = NA, yaxl = "percent",
-  legend = list("top!", title = NULL),
+  legend = list("top!", title = FALSE),
   theme = list("clean2", palette.qualitative = pal),
   main = "Likert example with \"Unsure\" category offset"
 )


### PR DESCRIPTION
FIxes #652

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
plt(mpg ~ wt | factor(am), mtcars, legend = list(title = FALSE, bty = "o"))
```

![](https://i.imgur.com/rqyrJD4.png)<!-- -->

<sup>Created on 2026-06-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

P.S. The existing `title = NA` behaviour (i.e., no legend but doesn't remove the spacing) is preserved since it follows the base `legend()` behaviour.
