### PR TITLE
Test infra: terminal container runner + snapshot toolchain fixes

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+.build-stamp-*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM rocker/r2u:24.04
+
+ENV NOT_CRAN=true
+
+# DejaVu Sans is pinned by inst/tinytest/helpers.R as the plotmath symbol font,
+# so make sure it is present (it is what CI's rocker image resolves to).
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends fonts-dejavu-core \
+ && rm -rf /var/lib/apt/lists/*
+
+# Test-suite R dependencies. On the rocker/r2u base, install.packages() is wired
+# to apt via bspm, so these resolve to prebuilt r-cran-* binaries (no source
+# compilation) -- the same mechanism as the devcontainer's postCreateCommand.
+# tinysnapshot pulls in magick + diffobj automatically.
+RUN R -e "install.packages(c('pkgload', 'tinytest', 'tinysnapshot', 'fontquiver', 'svglite', 'rsvg', 'png', 'knitr'))"
+
+WORKDIR /work
+
+CMD ["Rscript", "-e", "pkgload::load_all(quiet=TRUE);tinytest::run_test_dir('inst/tinytest')"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyplot devcontainer",
-  "image": "rocker/r2u:24.04",
-  
+  "build": { "dockerfile": "Dockerfile" },
+
   "containerEnv": {
     "NOT_CRAN": "true"
   },

--- a/.devcontainer/run-tests.sh
+++ b/.devcontainer/run-tests.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Run the tinyplot test suite inside a Linux container.
+#
+# Snapshot tests compare against SVGs rendered on Linux with Liberation fonts,
+# so they only pass in a Linux environment. This script provides a terminal
+# alternative to the VS Code devcontainer: same base image, no editor required.
+#
+# On Apple Silicon, native (arm64) runs produce a couple of snapshot diffs
+# because the reference SVGs were rendered on amd64 (CI). Use PLATFORM=linux/amd64
+# for an arm64-faithful, CI-matching run (slower, emulated). See `make testall-ci`.
+#
+# Usage:
+#   .devcontainer/run-tests.sh                       # whole suite
+#   .devcontainer/run-tests.sh inst/tinytest/test-legend.R   # one file
+#   .devcontainer/run-tests.sh -i                    # interactive R session
+#   .devcontainer/run-tests.sh -s                    # shell in the container
+#   .devcontainer/run-tests.sh -b                    # force image rebuild
+#
+# Env vars:
+#   RUNTIME   container CLI to use (default: first of docker/podman/finch/nerdctl)
+#   PLATFORM  e.g. linux/amd64 to match CI's architecture (default: native)
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="$REPO/.devcontainer/Dockerfile"
+
+# Tag per platform, so that native and emulated images coexist instead of
+# clobbering each other's tag and forcing a rebuild on every switch.
+if [[ -n "${PLATFORM:-}" ]]; then
+  IMAGE="tinyplot-test:${PLATFORM##*/}"
+else
+  IMAGE="tinyplot-test:local"
+fi
+
+# Pick a container runtime. Finch, nerdctl and podman are all CLI-compatible
+# with docker for the handful of subcommands used here.
+if [[ -z "${RUNTIME:-}" ]]; then
+  for c in docker podman finch nerdctl; do
+    if command -v "$c" >/dev/null 2>&1; then RUNTIME="$c"; break; fi
+  done
+fi
+if [[ -z "${RUNTIME:-}" ]]; then
+  echo "error: no container runtime found (tried docker, podman, finch, nerdctl)." >&2
+  echo "Set RUNTIME=<cli> to override." >&2
+  exit 1
+fi
+
+# Note: macOS ships bash 3.2, where expanding an empty array under `set -u`
+# is an "unbound variable" error, so every optional-args array below is guarded
+# with `${arr[@]+"${arr[@]}"}` rather than a bare `"${arr[@]}"`.
+PLATFORM_ARG=()
+[[ -n "${PLATFORM:-}" ]] && PLATFORM_ARG=(--platform "$PLATFORM")
+
+REBUILD=0
+MODE="test"
+while getopts ":bis" opt; do
+  case $opt in
+    b) REBUILD=1 ;;
+    i) MODE="R" ;;
+    s) MODE="shell" ;;
+    \?) echo "error: unknown option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+# Build if the image is missing, if -b was passed, or if the Dockerfile is
+# newer than the image we last built from it.
+STAMP="$REPO/.devcontainer/.build-stamp-${IMAGE##*:}"
+needs_build=$REBUILD
+if ! "$RUNTIME" image inspect "$IMAGE" >/dev/null 2>&1; then
+  needs_build=1
+elif [[ "$DOCKERFILE" -nt "$STAMP" ]]; then
+  needs_build=1
+fi
+
+if [[ $needs_build -eq 1 ]]; then
+  echo ">> building $IMAGE via $RUNTIME"
+  "$RUNTIME" build ${PLATFORM_ARG[@]+"${PLATFORM_ARG[@]}"} \
+    -t "$IMAGE" -f "$DOCKERFILE" "$REPO"
+  touch "$STAMP"
+fi
+
+# On Linux, bind-mounted files are written back as root unless we map the
+# caller's uid/gid. Docker Desktop, Finch and podman already handle this on
+# macOS, so only do it where it is needed.
+USER_ARG=()
+if [[ "$(uname -s)" == "Linux" && "$RUNTIME" != "podman" ]]; then
+  USER_ARG=(--user "$(id -u):$(id -g)")
+fi
+
+RUN=("$RUNTIME" run --rm
+     ${PLATFORM_ARG[@]+"${PLATFORM_ARG[@]}"}
+     ${USER_ARG[@]+"${USER_ARG[@]}"}
+     -v "$REPO":/work -w /work -e NOT_CRAN=true)
+
+case "$MODE" in
+  shell) exec "${RUN[@]}" -it "$IMAGE" bash ;;
+  R)     exec "${RUN[@]}" -it "$IMAGE" R -q ;;
+esac
+
+if [[ $# -gt 0 ]]; then
+  # Run only the named test file(s).
+  for f in "$@"; do
+    echo ">> $f"
+    "${RUN[@]}" "$IMAGE" Rscript -e \
+      "pkgload::load_all(quiet=TRUE);tinytest::run_test_file('$f')"
+  done
+else
+  exec "${RUN[@]}" "$IMAGE" Rscript -e \
+    "pkgload::load_all(quiet=TRUE);tinytest::run_test_dir('inst/tinytest')"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,28 +130,30 @@ When multiple groups share the same x-position (boxplot, violin, etc.), offsets 
 
 ## Testing & CI
 
-Tests use `tinytest` + `tinysnapshot`. Snapshot tests produce SVG output with Liberation fonts and must be run on Linux (`options("tinysnapshot_os" = "Linux")`). For non-Linux users, we provide a dedicated `.devcontainer` for running tests via VS Code or GitHub Codespaces:
-1. Open repo in VS Code
-2. Command Palette → "Dev Containers: Reopen in Container"
-3. Dependencies install automatically
+Tests use `tinytest` + `tinysnapshot`. Snapshot tests produce SVG output with Liberation fonts and are meant to run on **Linux** (`helpers.R` sets `tinysnapshot_os = "Linux"`); they only run when the environment variable `NOT_CRAN` is set to the lowercase string `"true"`. Non-snapshot tests (logical assertions, error checks) run anywhere.
 
-Non-snapshot tests (logical assertions, error checks, etc.) run fine on any platform. Even with the devcontainer, a small number of snapshot tests (~2-3) may produce false positive failures on macOS hosts due to imperceptible rendering differences. These show up in `inst/tinytest/_tinysnapshot_review/` but the visual differences are too small to detect by eye. Known false positives:
-
-- `xaxl_yaxl`
-- `palette_manual_continuous`
-
-This is a known quirk — don't worry about these specific persistent failures. However, if you see more than ~3 snapshot failures, something real is likely broken and needs investigation.
+On Linux you can generally just run the suite directly and expect it to match CI. Snapshots are byte-compared against amd64 reference images, so the usual things that trip people up are (a) not being on Linux/amd64, and (b) a stale render toolchain — e.g. distro/PPM package binaries built against an older R after a minor bump, which make `svglite`/`systemfonts`/`textshaping`/`rsvg`/`magick` error or drift. A handful of pure text/glyph-metric diffs (titles, themed labels, plotmath) almost always means one of those, not a code regression; a larger or structural set of failures is the real thing. CI is the final arbiter.
 
 ### Running Tests
 
-The canonical test workflow is to open the devcontainer and run `make testall`. Do not attempt to run the full test suite outside the devcontainer — snapshot tests will fail due to font/rendering differences, and even non-snapshot tests may pull in snapshot comparisons.
+Pick the path that fits your setup:
+
+**Native Linux (amd64) — fastest.** `make testall` runs directly against your R install and should match CI. Snapshots only run with `NOT_CRAN=true` set (lowercase). If the render stack errors ("Graphics API version mismatch") or snapshots drift, it's the stale-toolchain gotcha above — reinstall `svglite`, `magick`, `rsvg`, `systemfonts`, `textshaping` from source.
+
+**VS Code devcontainer (any OS).** Open the repo in VS Code → Command Palette → "Dev Containers: Reopen in Container" (deps install automatically), then `make testall`. Also works via GitHub Codespaces.
+
+**Terminal container runner (any OS with Docker/Podman/Finch/nerdctl).** No editor required:
+- `make testall-docker` — full suite in a Linux container at your native architecture.
+- `make testall-ci` — same, forced to amd64 (`--platform linux/amd64`). **On Apple Silicon this is the CI-faithful run**: arm64-native rendering differs subtly from the amd64 reference SVGs, so a native-arch run shows a couple of spurious text-snapshot diffs. It's emulated (slower), so iterate with `testall-docker` and confirm with `testall-ci` before pushing.
 
 ```bash
-# Via Makefile (inside devcontainer)
-make testall                                          # Run all tests
-make testone testfile="inst/tinytest/test-legend.R"   # Run single test file
+make testall            # native Linux host
+make testall-docker     # container, native arch
+make testall-ci         # container, amd64 (CI-faithful; needed on Apple Silicon)
+make testone testfile="inst/tinytest/test-legend.R"       # single file, native
+.devcontainer/run-tests.sh inst/tinytest/test-legend.R    # single file, container
 
-# Via R
+# Via R (Linux, NOT_CRAN=true)
 tinytest::run_test_dir("inst/tinytest")
 tinytest::run_test_file("inst/tinytest/test-legend.R")
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help testall testone document check install 
+.PHONY: help testall testone testall-docker testall-ci document check install
 
 help:  ## Display this help screen
 	@echo -e "\033[1mAvailable commands:\033[0m\n"
@@ -6,6 +6,12 @@ help:  ## Display this help screen
 
 testall: ## tinytest::build_install_test()
 	Rscript -e "pkgload::load_all();tinytest::run_test_dir()"
+
+testall-docker: ## run full test suite in a Linux container (native arch)
+	.devcontainer/run-tests.sh
+
+testall-ci: ## as testall-docker, under amd64 to match CI (needed on Apple Silicon; slower)
+	PLATFORM=linux/amd64 .devcontainer/run-tests.sh
 
 testone: install ## make testone testfile="inst/tinytest/test-aaa-warn_once.R"
 	Rscript -e "pkgload::load_all();tinytest::run_test_file('$(testfile)')"

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -7,7 +7,12 @@ library(tinysnapshot)
 
 options("tinysnapshot_os" = "Linux")
 options("tinysnapshot_device" = "svglite")
-options("tinysnapshot_device_args" = list(user_fonts = fontquiver::font_families("Liberation")))
+options("tinysnapshot_device_args" = list(
+  user_fonts = fontquiver::font_families("Liberation"),
+  # Pin the plotmath symbol font (face 5) so it doesn't drift to a system
+  # symbol font (e.g. Arch's "Standard Symbols PS") instead of CI's DejaVu Sans.
+  system_fonts = list(symbol = "DejaVu Sans")
+))
 
 # reset theme in every file
 tinytheme()


### PR DESCRIPTION
## What

Test-infrastructure updates: a terminal-based container test runner, a fix for plotmath snapshot drift, and a rewrite of the CLAUDE.md testing docs.

### Commits
- **`test: dejavu symbol gotcha`** — pin the plotmath symbol font (font face 5) to DejaVu Sans via svglite's `system_fonts` alias in `helpers.R`. Liberation ships no symbol font, so svglite resolves face 5 through the OS-native fontconfig match — DejaVu Sans on CI, but a URW "Standard Symbols PS"-style font on hosts that ship one (e.g. Arch's `gsfonts`), causing snapshot drift. `systemfonts::register_font()` can't reach this path; the device-level `system_fonts` alias can. CI already falls back to DejaVu Sans, so its output is unchanged.
- **`test: add terminal container test runner`** — `.devcontainer/Dockerfile` (r2u base, `install.packages()` style, `fonts-dejavu-core`) + `run-tests.sh` (auto-detects docker/podman/finch/nerdctl; maps uid/gid on Linux), wired up as `make testall-docker` (native arch) and `make testall-ci` (amd64, for arm64/Apple Silicon fidelity).
- **`docs: rewrite testing section for per-OS options`** — present the native-Linux / devcontainer / terminal-container paths and when to use each; reframe local↔CI snapshot divergence as a toolchain (version/arch) matter rather than an inevitable macOS quirk.
- **`chore: build devcontainer from shared Dockerfile`** — `devcontainer.json` now builds from the shared Dockerfile so VS Code users get the same baked-in test stack + DejaVu font.

## Why / findings

Local↔CI snapshot divergence is driven by **toolchain/version pinning**, not architecture per se. Two gotchas surfaced while getting a native Linux host to a clean run:
- **Stale render-stack binaries** (distro/PPM builds compiled against an older R after a minor bump) cause `svglite`/`magick`/`rsvg`/`systemfonts`/`textshaping` to error ("Graphics API version mismatch") or drift — reinstall from source.
- **arm64 vs amd64** rendering differs subtly from the amd64 reference SVGs, so Apple Silicon needs the emulated `make testall-ci` for a CI-faithful run.

## Verified
- Native Linux (amd64): **579/579**
- `make testall-docker` (amd64 Linux host): **579/579**, uid mapping clean, build caching works

## ⚠️ Still needs testing on macOS

Everything above was exercised only on a **native amd64 Linux** host. Not yet verified on Apple Silicon:
- `make testall-ci` under real `linux/amd64` **emulation** (here it ran native, so QEMU/Rosetta routing is untested)
- native-arch `make testall-docker` behaviour on arm64
- the DejaVu symbol pin under arm64 rendering
- the `devcontainer.json` → Dockerfile build via VS Code on macOS

Also: the `helpers.R` symbol pin's claim that CI output is unchanged relies on this PR's CI run to confirm the committed references still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
